### PR TITLE
Fix for #161

### DIFF
--- a/www/js/utils/languages.js
+++ b/www/js/utils/languages.js
@@ -70738,12 +70738,13 @@ define(function (require) {
             deferred.resolve(language);
             return deferred.promise();
         },
-
+        
         findByName = function (searchKey) {
             var deferred = $.Deferred();
             var fullresults = languages.filter(function (element) {
                 return (element.Ref_Name.toLowerCase().indexOf(searchKey.toLowerCase()) > -1) ||
-                    (element.Id.toLowerCase().indexOf(searchKey.toLowerCase()) > -1);
+                    (element.Id.toLowerCase().indexOf(searchKey.toLowerCase()) > -1) ||
+                    (element.Part1.toLowerCase().indexOf(searchKey.toLowerCase()) > -1);
             });
             var results = Underscore.first(fullresults, 200);
             deferred.resolve(results);

--- a/www/tpl/LanguagesList.html
+++ b/www/tpl/LanguagesList.html
@@ -2,6 +2,12 @@
     Template for rendering the languages that match the search list on the project source and target language pages.
     This template is compiled by LanguagesView and called from ProjectSourceLanguageView.js and ProjectTargetLanguageView.js.
 }}
+{{#if this.Part1}}
+<div class="autocomplete-suggestion" data-index="{{@index}}" id="{{this.Part1}}">
+    ({{this.Part1}})&nbsp;{{this.Ref_Name}}
+</div>
+{{else}}
 <div class="autocomplete-suggestion" data-index="{{@index}}" id="{{this.Id}}">
     ({{this.Id}})&nbsp;{{this.Ref_Name}}
 </div>
+{{/if}}


### PR DESCRIPTION
Both 3-letter and 2-letter (when available) language codes are defined
in languages.js; to address this, the 2-letter code is displayed and
selected if it exists.