### PR TITLE
Update sqlite plugin to PG Build compatible fork

### DIFF
--- a/www/config.xml
+++ b/www/config.xml
@@ -36,7 +36,8 @@
     <plugin name="cordova-plugin-dialogs" source="npm" spec="1.3.0" />
     <plugin name="cordova-plugin-fonts" source="npm" spec="0.6.5" />
     <plugin name="cordova-plugin-splashscreen" source="npm" spec="4.0.0" />
-    <plugin name="cordova-sqlite-storage" source="npm" spec="1.4.7" /> <!-- 1.4.1 -->
+    <!-- sqlite plugin version compatible w/PG build -->
+    <plugin name="cordova-sqlite-evcore-extbuild-free" source="npm" spec="0.8.2" />
     <plugin name="cordova-plugin-whitelist" source="npm" spec="1.3.0" />
 
     <!-- PhoneGap Build - config-file tweaks - orientation (iOS) and allowing sdcard reading (Android)


### PR DESCRIPTION
PG build break — see
https://github.com/litehelpers/Cordova-sqlite-storage/issues/477