### PR TITLE
Fix issue #188

### DIFF
--- a/merges/ios/res/css/overrides.css
+++ b/merges/ios/res/css/overrides.css
@@ -11,9 +11,9 @@
     top: 132px;
 }
 /* iOS -- hide the prev/next toolbar buttons (they are on the on-screen keyboard) */
-#Next {
+#NextSP {
     display: none;
 }
-#Prev {
+#PrevSP {
     display: none;
 }

--- a/www/js/views/AdaptViews.js
+++ b/www/js/views/AdaptViews.js
@@ -1002,8 +1002,8 @@ define(function (require) {
                 project.set('lastAdaptedSPID', selectedStart.id);
 
                 // enable prev / next buttons
-                $("#Prev").prop('disabled', false); // enable toolbar button
-                $("#Next").prop('disabled', false); // enable toolbar button
+                $("#PrevSP").prop('disabled', false); // enable toolbar button
+                $("#NextSP").prop('disabled', false); // enable toolbar button
                 // Is the target field empty?
                 if ($(event.currentTarget).text().trim().length === 0) {
                     // target is empty -- attempt to populate it
@@ -1715,8 +1715,8 @@ define(function (require) {
             ////
             events: {
                 "click #chapter": "unselectPiles",
-                "click #Prev": "goPrevPile",
-                "click #Next": "goNextPile",
+                "click #PrevSP": "goPrevPile",
+                "click #NextSP": "goNextPile",
                 "click #Placeholder": "togglePlaceholder",
                 "click #Phrase": "togglePhrase",
                 "click #Retranslation": "toggleRetranslation",

--- a/www/tpl/Chapter.html
+++ b/www/tpl/Chapter.html
@@ -28,10 +28,10 @@
          <button id="Retranslation" title="{{ t 'view.dscRetranslation'}}" class="topcoat-icon-button toolbar-button" disabled><span class="topcoat-icon topcoat-icon--retranslation-new"></span><span class="side-nav__list__item__label">{{ t 'view.lblRetranslation'}}</span></button>
     </div>
     <div class="toolbar__item right">
-         <button id="Next" title="{{ t 'view.lblNext'}}" class="topcoat-icon-button toolbar-button" disabled><span class="topcoat-icon topcoat-icon--next"></span><span class="side-nav__list__item__label">{{ t 'view.lblNext'}}</span></button>
+         <button id="NextSP" title="{{ t 'view.lblNext'}}" class="topcoat-icon-button toolbar-button" disabled><span class="topcoat-icon topcoat-icon--next"></span><span class="side-nav__list__item__label">{{ t 'view.lblNext'}}</span></button>
     </div>
     <div class="toolbar__item right">
-         <button id="Prev" title="{{ t 'view.lblPrev'}}" class="topcoat-icon-button toolbar-button" disabled><span  class="topcoat-icon topcoat-icon--prev"></span><span class="side-nav__list__item__label">{{ t 'view.lblPrev'}}</span></button>
+         <button id="PrevSP" title="{{ t 'view.lblPrev'}}" class="topcoat-icon-button toolbar-button" disabled><span  class="topcoat-icon topcoat-icon--prev"></span><span class="side-nav__list__item__label">{{ t 'view.lblPrev'}}</span></button>
     </div>
 </div>
 <div class="topcoat-list__container scroller-tb" id="content">


### PR DESCRIPTION
There was a name collision between the Next/Previous buttons for the
Adaptation toolbar and the Create Project wizard buttons. Changed the
name for the toolbar, so that the overrides.css file would only hide
that set.