### PR TITLE
Missed a touchend event

### DIFF
--- a/www/js/views/AdaptViews.js
+++ b/www/js/views/AdaptViews.js
@@ -622,6 +622,7 @@ define(function (require) {
                 "touchend .marker": "selectingPilesEnd",
                 "mouseup .filter": "showFilter",
                 "touchend .filter": "showFilter",
+                "touchend .pile": "checkStopSelecting",
                 "mouseup .pile": "checkStopSelecting",
                 "mousedown .target": "selectingAdaptation",
                 "touchstart .target": "selectingAdaptation",


### PR DESCRIPTION
Call helper method to address “fat finger” selections on touch devices
(it’s already being called for the mouse). While I’m not seeing issues
on my touch devices, it’s possible this is causing the problems Bruce
is seeing.