### PR TITLE
PG build fix

### DIFF
--- a/www/config.xml
+++ b/www/config.xml
@@ -41,6 +41,7 @@
     <!-- sqlite plugin version compatible w/PG build -->
     <plugin name="cordova-sqlite-evcore-extbuild-free" source="npm" spec="0.8.6" />
     <plugin name="cordova-plugin-whitelist" source="npm" spec="1.3.2" />
+    <plugin name="cordova.plugins.diagnostic" spec="^3.7.1" />
 
     <!-- PhoneGap Build - config-file tweaks - orientation (iOS) and allowing sdcard reading (Android)
     (see http://phonegap.com/blog/2014/01/30/customizing-your-android-manifest-and-ios-property-list-on-phonegap-build/)


### PR DESCRIPTION
diagnostic plugin wasn’t being added to the PhoneGap build.