### PR TITLE
Fix #283

### DIFF
--- a/www/res/css/styles.css
+++ b/www/res/css/styles.css
@@ -1190,9 +1190,12 @@ background-color: #fff;
 }
 
 .tt-suggestion {
-  padding: 3px 20px;
-  font-size: 16px;
-  line-height: 2rem;
+/*    padding 3px;*/
+    padding: 3px 20px;
+    font-size: 16px;
+    line-height: 2rem;
+    overflow: hidden;
+/*    width: auto;*/
 }
 
 .tt-suggestion:hover {


### PR DESCRIPTION
Includes other selection / typeahead cleanup: Weird “phantom” selection
after undo (removing selection ranges on blur), fixing typeahead
selection (only a problem inside this milestone), making sure we blur
the old target if a new pile is selected.