### PR TITLE
Fix #298

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "gulp-typescript": "latest",
     "plist": "^1.2.0"
   },
-
   "dependencies": {
     "cordova-android": "^6.3.0",
     "cordova-ios": "^4.5.4",
     "cordova-lib": "^7.1.0",
+    "cordova-plugin-appversion": "1.0.0",
     "cordova-plugin-device": "1.1.7",
     "cordova-plugin-dialogs": "1.3.4",
     "cordova-plugin-file": "5.0.0",
@@ -61,6 +61,7 @@
   },
   "cordova": {
     "plugins": {
+      "cordova-plugin-appversion": {},
       "cordova-plugin-device": {},
       "cordova-plugin-dialogs": {},
       "cordova-plugin-file": {},

--- a/www/config.xml
+++ b/www/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget defaultlocale="en" id="org.adaptit.adaptitmobile" version="1.0.0" android-versionCode="1" ios-CFBundleVersion="1.0.0b11" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:gap="http://phonegap.com/ns/1.0" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="1" defaultlocale="en" id="org.adaptit.adaptitmobile" ios-CFBundleVersion="1.0.0b11" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:gap="http://phonegap.com/ns/1.0">
     <name short="aim" xml:lang="en">Adapt It Mobile</name>
     <description xml:lang="en">
         An open source application for translating between related languages.
@@ -87,6 +87,7 @@
         <icon src="res/icon/windows/Wide310x150Logo.png" target="Wide310x150Logo" />
         <splash src="res/screen/windows/splashscreen.png" target="SplashScreen" />
     </platform>
+    <plugin name="cordova-plugin-appversion" spec="1.0.0" />
     <plugin name="cordova-plugin-device" spec="1.1.7" />
     <plugin name="cordova-plugin-dialogs" spec="1.3.4" />
     <plugin name="cordova-plugin-file" spec="5.0.0" />
@@ -94,7 +95,7 @@
     <plugin name="cordova-plugin-keyboard" spec="1.1.5" />
     <plugin name="cordova-plugin-splashscreen" spec="4.1.0" />
     <plugin name="cordova-plugin-statusbar" spec="2.3.0" />
-    <plugin name="cordova-plugin-whitelist" spec="1.3.3" />
+    <plugin name="cordova-plugin-whitelist" spec="1.3.2" />
     <plugin name="cordova-sqlite-evcore-extbuild-free" spec="0.8.6" />
     <plugin name="cordova.plugins.diagnostic" spec="^3.7.1" />
 </widget>

--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -44,6 +44,7 @@ define(function (require) {
             filterlist: "",
             currentProject: null,
             localURLs: [],
+            version: "1.0.0", // replaced with the actual version on device ready
             
             // App initialization code. App initialization comes in a few callbacks:
             // 1. Cordova initialization (startTheApp() in main.js)
@@ -77,6 +78,11 @@ define(function (require) {
                     // a couple iOS-specific settings
                     Keyboard.shrinkView(true); // resize the view when the keyboard displays
                     Keyboard.hideFormAccessoryBar(true); // don't show the iOS "<> Done" line
+                }
+                // version info (mobile app only)
+                if (window.sqlitePlugin) {
+                    // return both version and build info
+                    this.version = AppVersion.version + "(" + AppVersion.build + ")";
                 }
                 // local dirs (mobile app only)
                 if (window.sqlitePlugin) {

--- a/www/js/utils/HandlebarHelpers.js
+++ b/www/js/utils/HandlebarHelpers.js
@@ -101,6 +101,11 @@ define(function (require) {
         return new Handlebars.SafeString(result);
     });
     
+    Handlebars.registerHelper('AppVersion', function () {
+        var result = window.Application.version;
+        return new Handlebars.SafeString(result);
+    });
+    
     // If/then processing helper:
     // Handlebars doesn't directly perform conditional expression evaluation, so we
     // need to roll our own.

--- a/www/locales/dev/translation.json
+++ b/www/locales/dev/translation.json
@@ -241,9 +241,11 @@
         "lblFrench": "Français",
         "lblPortuguese": "Português",
         "lblTokPisin": "Tok Pisin",
+        "lblGeneralSettings": "General Settings",
         "lblEditor": "Editor",
         "lblCopySource": "Copy Source",
         "lblWrapAtUSFM": "Wrap at Standard Format Markers",
+        "AppVersion": "App Version",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/en/translation.json
+++ b/www/locales/en/translation.json
@@ -241,9 +241,11 @@
         "lblFrench": "Français",
         "lblPortuguese": "Português",
         "lblTokPisin": "Tok Pisin",
+        "lblGeneralSettings": "General Settings",
         "lblEditor": "Editor",
         "lblCopySource": "Copy Source",
         "lblWrapAtUSFM": "Wrap at Standard Format Markers",
+        "AppVersion": "App Version",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/es/translation.json
+++ b/www/locales/es/translation.json
@@ -241,9 +241,11 @@
         "lblFrench": "Français",
         "lblPortuguese": "Português",
         "lblTokPisin": "Tok Pisin",
+        "lblGeneralSettings": "Configuración general",
         "lblEditor": "Editor",
-        "lblCopySource": "Copy Source",
-        "lblWrapAtUSFM": "Wrap at Standard Format Markers",
+        "lblCopySource": "Copiar el texto original",
+        "lblWrapAtUSFM": "Ajustar el texto a los marcadores USFM",
+        "AppVersion": "Versión de la aplicación",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/fr/translation.json
+++ b/www/locales/fr/translation.json
@@ -241,9 +241,11 @@
         "lblFrench": "Français",
         "lblPortuguese": "Português",
         "lblTokPisin": "Tok Pisin",
-        "lblEditor": "Editor",
-        "lblCopySource": "Copy Source",
-        "lblWrapAtUSFM": "Wrap at Standard Format Markers",
+        "lblGeneralSettings": "Réglages généraux",
+        "lblEditor": "Éditeur",
+        "lblCopySource": "Copier le texte source",
+        "lblWrapAtUSFM": "Enveloppez le texte aux marqueurs USFM",
+        "AppVersion": "Version de l'application",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/hi/translation.json
+++ b/www/locales/hi/translation.json
@@ -241,9 +241,11 @@
         "lblFrench": "Français",
         "lblPortuguese": "Português",
         "lblTokPisin": "Tok Pisin",
+        "lblGeneralSettings": "General Settings",
         "lblEditor": "Editor",
         "lblCopySource": "Copy Source",
         "lblWrapAtUSFM": "Wrap at Standard Format Markers",
+        "AppVersion": "App Version",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/pt/translation.json
+++ b/www/locales/pt/translation.json
@@ -241,9 +241,11 @@
         "lblFrench": "Français",
         "lblPortuguese": "Português",
         "lblTokPisin": "Tok Pisin",
+        "lblGeneralSettings": "Configurações Gerais",
         "lblEditor": "Editor",
         "lblCopySource": "Copiar texto de origem",
         "lblWrapAtUSFM": "Embrulhe o texto nos marcadores USFM",
+        "AppVersion": "Versão do aplicativo",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/tpi/translation.json
+++ b/www/locales/tpi/translation.json
@@ -241,9 +241,11 @@
         "lblFrench": "Français",
         "lblPortuguese": "Português",
         "lblTokPisin": "Tok Pisin",
+        "lblGeneralSettings": "General Settings",
         "lblEditor": "Editor",
         "lblCopySource": "Copy Source",
         "lblWrapAtUSFM": "Wrap at Standard Format Markers",
+        "AppVersion": "App Version",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/tpl/EditProject.html
+++ b/www/tpl/EditProject.html
@@ -20,7 +20,7 @@
 <ul class="chapter-list topcoat-list__container" id="ProjectItems">
 <li class="topcoat-list__item">
     <a id="EditorUIPrefs">
-    <header><h3>Editor and User Interface</h3></header>
+    <header><h3>{{t 'view.lblGeneralSettings'}}</h3></header>
     <div class="control-row"></div>
     <span class="chevron" style="top:1.25rem;"></span></a>
 </li>

--- a/www/tpl/EditorPrefs.html
+++ b/www/tpl/EditorPrefs.html
@@ -3,6 +3,7 @@
 <div class="control-row" style="padding-left:6px;"><label class="topcoat-checkbox"><input type="checkbox" id="CopySource" value="false"> <div class="topcoat-checkbox__checkmark"></div>{{t 'view.lblCopySource'}}</label></div>
 <div class="control-row" style="padding-left:6px;"><label class="topcoat-checkbox"><input type="checkbox" id="WrapAtMarker" value="false"> <div class="topcoat-checkbox__checkmark"></div>{{t 'view.lblWrapAtUSFM'}}</label></div>
 </div>
+<div class="control-row"></div>
 <div class="control-group">
 <div class="control-row">{{ t 'view.ttlLanguage'}}</div>
 <div class="control-row"><label class="topcoat-radio-button"><input type="radio" id="deviceLanguage" name="topcoat">
@@ -20,3 +21,9 @@
     </select>
 </div>
 </div>
+<div class="control-row"></div>
+<div class="control-row" style="border-top:1px solid #949696;"><ul class="topcoat-list__container chapter-list">
+<li class="topcoat-list__item">
+    <a id="aboutAIM"><header><h3>{{t 'view.AppVersion'}}</h3><span style="float: right">{{AppVersion}}</span></header></a>
+</li>
+</ul></div>


### PR DESCRIPTION
Version info is gathered at runtime via the cordova-plugin-appversion
API. This is displayed in the Editor / UI language prefs page. Also
added a couple localization strings that I missed on an earlier checkin.