### PR TITLE
Fix #298

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cordova-android": "^6.3.0",
     "cordova-ios": "^4.5.4",
     "cordova-lib": "^7.1.0",
-    "cordova-plugin-appversion": "1.0.0",
+    "cordova-plugin-appversion": "1.0.1",
     "cordova-plugin-device": "1.1.7",
     "cordova-plugin-dialogs": "1.3.4",
     "cordova-plugin-file": "5.0.0",
@@ -61,7 +61,6 @@
   },
   "cordova": {
     "plugins": {
-      "cordova-plugin-appversion": {},
       "cordova-plugin-device": {},
       "cordova-plugin-dialogs": {},
       "cordova-plugin-file": {},
@@ -71,7 +70,8 @@
       "cordova-plugin-statusbar": {},
       "cordova-plugin-whitelist": {},
       "cordova-sqlite-evcore-extbuild-free": {},
-      "cordova.plugins.diagnostic": {}
+      "cordova.plugins.diagnostic": {},
+      "cordova-plugin-appversion": {}
     },
     "platforms": []
   }

--- a/www/config.xml
+++ b/www/config.xml
@@ -87,7 +87,6 @@
         <icon src="res/icon/windows/Wide310x150Logo.png" target="Wide310x150Logo" />
         <splash src="res/screen/windows/splashscreen.png" target="SplashScreen" />
     </platform>
-    <plugin name="cordova-plugin-appversion" spec="1.0.0" />
     <plugin name="cordova-plugin-device" spec="1.1.7" />
     <plugin name="cordova-plugin-dialogs" spec="1.3.4" />
     <plugin name="cordova-plugin-file" spec="5.0.0" />
@@ -98,4 +97,5 @@
     <plugin name="cordova-plugin-whitelist" spec="1.3.2" />
     <plugin name="cordova-sqlite-evcore-extbuild-free" spec="0.8.6" />
     <plugin name="cordova.plugins.diagnostic" spec="^3.7.1" />
+    <plugin name="cordova-plugin-appversion" spec="1.0.1" />
 </widget>

--- a/www/config.xml
+++ b/www/config.xml
@@ -97,5 +97,5 @@
     <plugin name="cordova-plugin-whitelist" spec="1.3.2" />
     <plugin name="cordova-sqlite-evcore-extbuild-free" spec="0.8.6" />
     <plugin name="cordova.plugins.diagnostic" spec="^3.7.1" />
-    <plugin name="cordova-plugin-appversion" spec="1.0.1" />
+    <plugin name="cordova-plugin-appversion" spec="https://github.com/adapt-it/cordova-plugin-app-version.git#1.0.1" />
 </widget>

--- a/www/config.xml
+++ b/www/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="1" defaultlocale="en" id="org.adaptit.adaptitmobile" ios-CFBundleVersion="1.0.0b11" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:gap="http://phonegap.com/ns/1.0">
+<widget android-versionCode="21" defaultlocale="en" id="org.adaptit.adaptitmobile" ios-CFBundleVersion="1.0.0b11" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:gap="http://phonegap.com/ns/1.0">
     <name short="aim" xml:lang="en">Adapt It Mobile</name>
     <description xml:lang="en">
         An open source application for translating between related languages.

--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -82,7 +82,7 @@ define(function (require) {
                 // version info (mobile app only)
                 if (window.sqlitePlugin) {
                     // return both version and build info
-                    this.version = AppVersion.version + "(" + AppVersion.build + ")";
+                    this.version = AppVersion.version + " (" + AppVersion.buildString + ")";
                 }
                 // local dirs (mobile app only)
                 if (window.sqlitePlugin) {


### PR DESCRIPTION
Fixes #298  .

Changes proposed in this request: Needed to refer to our own fork of cordova-plugin-appversion, as the base plugin does not account for semantic versioning in the build string (it converts it to a number, which only works on Android). If and when I get a response about incorporating the fix into the upstream plugin, I'll update the reference to the official plugin within our code.

The app version is displayed on the Settings, under General Settings; the line shows the released version number (1.0.0 currently) followed by the build info in parentheses: 

- on iOS, the build info follows semantic versioning. Currently we're at 1.0.0 beta 11, which is displayed as `1.0.0b11`.
- on Android, the build is a number that's just internal. I'm going with the number of milestone releases as the build number, which will be `21` for the next release.


@adapt-it/developers