### PR TITLE
Keep chapter and verse number with text

### DIFF
--- a/www/js/utils/HandlebarHelpers.js
+++ b/www/js/utils/HandlebarHelpers.js
@@ -45,6 +45,7 @@ define(function (require) {
         var ary = this.markers.split("\\"),
             result = "",
             filtered = false,
+            tmpString = "",
             filterString = window.Application.filterList,
             newID = Underscore.uniqueId(),
             i = 0;
@@ -60,6 +61,12 @@ define(function (require) {
                 result += "usfm-" + ary[i].substring(0, (ary[i].indexOf(" ") === -1) ? ary[i].length : ary[i].indexOf(" "));
                 if (filterString.indexOf("\\" + ary[i].trim() + " ") >= 0) {
                     filtered = true;
+                }
+                // Chapter and verse numbers come in a strip just before the actual marker (here) --
+                // we need to remove any paragraph breaks here so that the chapter / verse # appear on the same line
+                if ((this.markers.indexOf("\\c") > -1) || (this.markers.indexOf("\\v") > -1)) {
+                    tmpString = result.replace("usfm-p", " "); // remove para mark (css class only)
+                    result = tmpString;
                 }
             }
         }

--- a/www/js/views/AdaptViews.js
+++ b/www/js/views/AdaptViews.js
@@ -363,7 +363,11 @@ define(function (require) {
                 theRule = ".usfm-p,.usfm-mt1, .usfm-mt2, .usfm-mt3, .usfm-c { clear: none; }";
                 sheet.insertRule(theRule, sheet.cssRules.length); // add to the end (last rule wins)
             } else {
-                theRule = ".usfm-p,.usfm-mt1, .usfm-mt2, .usfm-mt3, .usfm-c { clear: left; }";
+                if (project.get('SourceDir') === 'rtl') {
+                    theRule = ".usfm-p,.usfm-mt1, .usfm-mt2, .usfm-mt3, .sh { clear: right; }";
+                } else {
+                    theRule = ".usfm-p,.usfm-mt1, .usfm-mt2, .usfm-mt3, .sh { clear: left; }";
+                }
                 sheet.insertRule(theRule, sheet.cssRules.length); // add to the end (last rule wins)
             }
         },

--- a/www/res/css/styles.css
+++ b/www/res/css/styles.css
@@ -863,7 +863,7 @@ div.strip.specialtext div.source {
 }
 
 /* Paragraph markers -- start on a new line (overridden in AdaptViews.js) */
-.usfm-p,.usfm-mt1, .usfm-mt2, .usfm-mt3, .usfm-c {
+.usfm-p,.usfm-mt1, .usfm-mt2, .usfm-mt3 {
     clear: left;
 }
 /* Filtered text -- rendered by the "classes" handlebar helper (see sourcephraselist.html / handlebarhelpers.js) */

--- a/www/tpl/SourcePhraseList.html
+++ b/www/tpl/SourcePhraseList.html
@@ -6,10 +6,10 @@
 {{#if this.markers}}{{#unless @first}}</div>{{/unless}}{{/if}}
 {{#if this.markers}}
 {{#ifCond this.markers 'contains' 'c '}}
-<div class="strip" id="strip-{{this.id}}-sh"><div id="header-{{this.id}}-c" class="strip-header block-height"><div class="chapter-number">{{chapter}}</div></div></div>
+<div class="strip sh" id="strip-{{this.id}}-sh"><div id="header-{{this.id}}-c" class="strip-header block-height"><div class="chapter-number">{{chapter}}</div></div></div>
 {{else}}
 {{#ifCond this.markers 'contains' 'v'}}
-<div class="strip" id="strip-{{this.id}}-sh"><div id="header-{{this.id}}-v" class="strip-header block-height"><div class="verse-number">{{verse}}</div></div></div>
+<div class="strip sh" id="strip-{{this.id}}-sh"><div id="header-{{this.id}}-v" class="strip-header block-height"><div class="verse-number">{{verse}}</div></div></div>
 {{/ifCond}}
 {{/ifCond}}
 <div class="strip{{classes}}" id="strip-{{this.id}}">


### PR DESCRIPTION
Also add a section head style for chapter and verse that follows the wrap at USFM break, so that chapter and verse numbers appear on a new line

Fixes # .

Changes proposed in this request:

-
-
-

@adapt-it/developers
