### PR TITLE
Fix #314

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "gulp": "^3.9.1",
     "gulp-typescript": "^2.11.0",
     "path": "^0.12.7",
+    "phonegap-plugin-mobile-accessibility": "https://github.com/phonegap/phonegap-mobile-accessibility.git",
     "plist": "^1.2.0"
   },
   "bugs": {
@@ -71,7 +72,8 @@
       "cordova-plugin-whitelist": {},
       "cordova-sqlite-evcore-extbuild-free": {},
       "cordova.plugins.diagnostic": {},
-      "cordova-plugin-appversion": {}
+      "cordova-plugin-appversion": {},
+      "phonegap-plugin-mobile-accessibility": {}
     },
     "platforms": []
   }

--- a/www/config.xml
+++ b/www/config.xml
@@ -98,4 +98,5 @@
     <plugin name="cordova-sqlite-evcore-extbuild-free" spec="0.8.6" />
     <plugin name="cordova.plugins.diagnostic" spec="^3.7.1" />
     <plugin name="cordova-plugin-appversion" spec="https://github.com/adapt-it/cordova-plugin-app-version.git" />
+    <plugin name="phonegap-plugin-mobile-accessibility" spec="https://github.com/phonegap/phonegap-mobile-accessibility.git" />
 </widget>

--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -79,6 +79,10 @@ define(function (require) {
                     Keyboard.shrinkView(true); // resize the view when the keyboard displays
                     Keyboard.hideFormAccessoryBar(true); // don't show the iOS "<> Done" line
                 }
+                // Window font size / zoom (Android only)
+                if (window.MobileAccessibility) {
+                    window.MobileAccessibility.usePreferredTextZoom(false);
+                }                
                 // version info (mobile app only)
                 if (window.sqlitePlugin) {
                     // return both version and build info


### PR DESCRIPTION
The fix here is to just ignore Android's Display > Font size setting altogether. This setting messes with the pixel size, but doesn't change the overall width of the screen (i.e., we can't detect it within our app). For those that have vision impairment issues, we do have font size settings within AIM that don't interfere with the toolbar / icon size.

Fixes #314  .

Changes proposed in this request:

-
-
-

@adapt-it/developers
