### PR TITLE
Issue #354

### DIFF
--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -84,8 +84,7 @@ define(function (require) {
                     window.MobileAccessibility.usePreferredTextZoom(false);
                 }                
                 // version info (mobile app only)
-                if (window.sqlitePlugin) {
-                    // return both version and build info
+                if (window.sqlitePlugin && AppVersion) {
                     this.version = AppVersion.version + " (" + AppVersion.buildString + ")";
                 }
                 // local dirs (mobile app only)

--- a/www/js/views/AdaptViews.js
+++ b/www/js/views/AdaptViews.js
@@ -1338,8 +1338,8 @@ define(function (require) {
 //                console.log("- scrollTop: " + $("#chapter").scrollTop() + ", offsetTop: " + $("#chapter").offset().top);
                 
                 // case where user lifted finger on the target instead of the pile
-                if (isSelecting === true) {
-                    console.log("oops... user mouseup on target, not pile... correcting.");
+                if (isSelecting === true || isLongPressSelection === true) {
+                    console.log("oops... pile selection / user mouseup on target, not pile... correcting.");
                     // trigger a click on the parent (pile) instead
                     $(event.parentElement).mouseup();
                     return;
@@ -2330,6 +2330,11 @@ define(function (require) {
                     $("#MoreActionsMenu").toggleClass("show");
                 }
                 if (selectedStart !== null) {
+                    // clear out any pile selection / long selection
+                    $("div").removeClass("ui-selecting ui-selected ui-longSelecting");
+                    LongPressSectionStart = null;
+                    isLongPressSelection = false;
+                    // move
                     isDirty = true;
                     MovingDir = -1; // backwards
                     this.listView.moveCursor(event, false);
@@ -2365,6 +2370,11 @@ define(function (require) {
                     $("#MoreActionsMenu").toggleClass("show");
                 }
                 if (selectedStart !== null) {
+                    // clear out any pile selection / long selection
+                    $("div").removeClass("ui-selecting ui-selected ui-longSelecting");
+                    LongPressSectionStart = null;
+                    isLongPressSelection = false;
+                    // move
                     isDirty = true;
                     MovingDir = 1; // forwards
                     this.listView.moveCursor(event, true);


### PR DESCRIPTION
Fixed a couple robustness issues with the long-press selection:
- cleared out the long-press flags before  calling movecursor() in the forward / backward button methods
- called the parent pile's event handler if the user releases in a target field AFTER the user has already selected the first pile in a long-press selection.

Fixes # .

Changes proposed in this request:

-
-
-

@adapt-it/developers
