### PR TITLE
Fix #382

### DIFF
--- a/www/config.xml
+++ b/www/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="28" defaultlocale="en" id="org.adaptit.adaptitmobile" ios-CFBundleVersion="1.2.0" version="1.2.0" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:gap="http://phonegap.com/ns/1.0">
+<widget android-versionCode="28" defaultlocale="en" id="org.adaptit.adaptitmobile" ios-CFBundleVersion="1.2.1" version="1.2.0" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:gap="http://phonegap.com/ns/1.0">
     <name short="Adapt It Mobile" xml:lang="en">Adapt It Mobile</name>
     <description xml:lang="en">
         An open source application for translating between related languages.

--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -77,7 +77,7 @@ define(function (require) {
             localURLs: [],
             version: "1.2.0", // appended with milestone / iOS build info
             MilestoneBuild: "28", // milestone release #
-            iOSBuild: "1.2.0",
+            iOSBuild: "1.2.1",
 
             // Mimics Element.scrollIntoView({"block": "center", "behavior": "smooth"}) for
             // browsers that do not support this scrollIntoViewOptions yet.

--- a/www/js/views/AdaptViews.js
+++ b/www/js/views/AdaptViews.js
@@ -2206,7 +2206,7 @@ define(function (require) {
                         // add any punctuation back to the target field
                         $(event.currentTarget).html(this.copyPunctuation(model, trimmedValue));
                         // update the model with the new target text
-                        model.save({target: Underscore.escape(this.copyPunctuation(model, trimmedValue))});
+                        model.save({target: this.copyPunctuation(model, trimmedValue)});
                         // if the target differs from the source, make it display in green
                         if (model.get('source') === model.get('target')) {
                             // source === target --> remove "differences" from the class so the text is black


### PR DESCRIPTION
Mismatched escape / unescape in model.save() call. This fix requires a bump in the iOS version, as the previous build version has been uploaded already.

Fixes # .

Changes proposed in this request:

-
-
-

@adapt-it/developers
