### PR TITLE
Update build numbers on iOS, Android

### DIFF
--- a/www/config.xml
+++ b/www/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="29" defaultlocale="en" id="org.adaptit.adaptitmobile" ios-CFBundleVersion="1.2.1" version="1.2.0" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:gap="http://phonegap.com/ns/1.0">
+<widget android-versionCode="30" defaultlocale="en" id="org.adaptit.adaptitmobile" ios-CFBundleVersion="1.2.1" version="1.2.0" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:gap="http://phonegap.com/ns/1.0">
     <name short="Adapt It Mobile" xml:lang="en">Adapt It Mobile</name>
     <description xml:lang="en">
         An open source application for translating between related languages.

--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -76,7 +76,7 @@ define(function (require) {
             currentProject: null,
             localURLs: [],
             version: "1.2.0", // appended with milestone / iOS build info
-            MilestoneBuild: "28", // milestone release #
+            AndroidBuild: "30", // (was milestone release #)
             iOSBuild: "1.2.1",
 
             // Mimics Element.scrollIntoView({"block": "center", "behavior": "smooth"}) for
@@ -131,8 +131,8 @@ define(function (require) {
                     // iOS - internal build #
                     this.version += " (" + this.iOSBuild + ")";
                 } else {
-                    // Android (+ Windows + browser) -- milestone release #
-                    this.version += " (" + this.MilestoneBuild + ")";
+                    // Android (+ Windows + browser) -- Android build #
+                    this.version += " (" + this.AndroidBuild + ")";
                 }
                 // local dirs (mobile app only)
                 if (window.sqlitePlugin) {


### PR DESCRIPTION
Android build number now separated from the milestone build (once build number goes live -- even in beta -- it can't be reused).

Fixes # .

Changes proposed in this request:

-
-
-

@adapt-it/developers
