### PR TITLE
Fix #390

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
       },
       "cordova-plugin-keyboard": {}
     },
-    "platforms": []
+    "platforms": [
+      "android",
+      "ios"
+    ]
   }
 }

--- a/www/js/views/ProjectViews.js
+++ b/www/js/views/ProjectViews.js
@@ -13,6 +13,7 @@ define(function (require) {
         Backbone        = require('backbone'),
         Handlebars      = require('handlebars'),
         Marionette      = require('marionette'),
+        cp              = require('colorpicker'),
         tplEditProject  = require('text!tpl/EditProject.html'),
         tplNewProject   = require('text!tpl/NewProject.html'),
         tplCopyOrImport = require('text!tpl/CopyOrImport.html'),


### PR DESCRIPTION
Missing colorpicker require statement (to load in the spectrum library)

Fixes # .

Changes proposed in this request:

-
-
-

@adapt-it/developers
