### PR TITLE
CLI build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,5 +230,5 @@ pip-log.txt
 #Mr Developer
 .mr.developer.cfg
 
-config.xml
+# config.xml (now used -- we're compiling from the CLI)
 package-lock.json

--- a/build.json
+++ b/build.json
@@ -1,0 +1,43 @@
+{
+    "android": {
+        "debug": {
+            "keystore": "../certs/aim.keystore",
+            "storePassword": "",
+            "alias": "",
+            "password" : "",
+            "keystoreType": ""
+        },
+        "release": {
+            "keystore": "../certs/aim.keystore",
+            "storePassword": "",
+            "alias": "",
+            "password" : "",
+            "keystoreType": ""
+        }
+    },
+
+    "ios": {
+        "debug": {
+            "codeSignIdentity": "iPhone Developer",
+            "developmentTeam": "DHTYBN4MGL",
+            "packageType": "development",
+            "automaticProvisioning": true,
+            "buildFlag": [
+                "EMBEDDED_CONTENT_CONTAINS_SWIFT = YES",
+                "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES=NO",
+                "LD_RUNPATH_SEARCH_PATHS = \"@executable_path/Frameworks\""
+            ]
+        },
+        "release": {
+            "codeSignIdentity": "iPhone Developer",
+            "developmentTeam": "DHTYBN4MGL",
+            "packageType": "app-store",
+            "automaticProvisioning": true,
+            "buildFlag": [
+                "EMBEDDED_CONTENT_CONTAINS_SWIFT = YES",
+                "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES=NO",
+                "LD_RUNPATH_SEARCH_PATHS = \"@executable_path/Frameworks\""
+            ]
+        }
+    }
+}

--- a/config.xml
+++ b/config.xml
@@ -27,6 +27,13 @@
         <preference name="AndroidPersistentFileLocation" value="Internal" />
         <preference name="android-minSdkVersion" value="22" />
         <preference name="android-targetSdkVersion" value="29" />
+        <config-file target="AndroidManifest.xml" mode="replace" parent="/manifest">
+            <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+            <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+            <uses-feature android:name="android.hardware.bluetooth" android:required="false"/>
+            <uses-feature android:name="android.hardware.faketouch" android:required="false"/>
+        </config-file>
         <icon density="ldpi" src="www/res/icon/android/ldpi.png" />
         <icon density="mdpi" src="www/res/icon/android/mdpi.png" />
         <icon density="hdpi" src="www/res/icon/android/hdpi.png" />
@@ -256,5 +263,4 @@
     <plugin name="cordova-plugin-network-information" spec="^2.0.2" />
     <plugin name="phonegap-plugin-mobile-accessibility" spec="https://github.com/phonegap/phonegap-mobile-accessibility.git" />
     <plugin name="cordova-clipboard" spec="https://github.com/ihadeed/cordova-clipboard.git" />
-    <engine name="android" />
 </widget>

--- a/config.xml
+++ b/config.xml
@@ -1,0 +1,260 @@
+<?xml version='1.0' encoding='utf-8'?>
+<widget android-versionCode="33" defaultlocale="en" id="org.adaptit.adaptitmobile" ios-CFBundleVersion="1.4.0" version="1.4.0" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:gap="http://phonegap.com/ns/1.0">
+    <name short="Adapt It Mobile" xml:lang="en">Adapt It Mobile</name>
+    <description xml:lang="en">
+        An open source application for translating between related languages.
+    </description>
+    <author email="developers@adapt-it.org" href="http://adapt-it.org/">
+        Adapt It Team
+    </author>
+    <content src="index.html" />
+    <access origin="*" />
+    <preference name="cordova.plugins.diagnostic.modules" value="BLUETOOTH WIFI EXTERNAL_STORAGE" />
+    <preference name="android-build-tool" value="gradle" />
+    <preference name="Orientation" value="default" />
+    <preference name="DisallowOverscroll" value="true" />
+    <preference name="iosExtraFilesystems" value="documents,documents-nosync,cache,root" />
+    <preference name="SplashScreenDelay" value="3000" />
+    <preference name="SplashMaintainAspectRatio" value="false" />
+    <preference name="SplashShowOnlyFirstTime" value="false" />
+    <preference name="AutoHideSplashScreen" value="true" />
+    <hook src="hooks/after_prepare/uglify.js" type="after_prepare" />
+    <platform name="android">
+        <plugin name="cordova-sqlite-evcore-extbuild-free" spec="^0.9.8" />
+        <plugin name="cordova-plugin-statusbar" spec="^2.4.3" />
+        <preference name="AndroidLaunchMode" value="singleTask" />
+        <preference name="AndroidExtraFilesystems" value="files,files-external,documents,sdcard,root" />
+        <preference name="AndroidPersistentFileLocation" value="Internal" />
+        <preference name="android-minSdkVersion" value="22" />
+        <preference name="android-targetSdkVersion" value="29" />
+        <icon density="ldpi" src="www/res/icon/android/ldpi.png" />
+        <icon density="mdpi" src="www/res/icon/android/mdpi.png" />
+        <icon density="hdpi" src="www/res/icon/android/hdpi.png" />
+        <icon density="xhdpi" src="www/res/icon/android/xhdpi.png" />
+        <icon density="xxhdpi" src="www/res/icon/android/xxhdpi.png" />
+        <icon density="xxxhdpi" src="www/res/icon/android/xxxhdpi.png" />
+        <splash density="port-ldpi" src="www/res/screen/android/screen-ldpi-portrait.png" />
+        <splash density="port-mdpi" src="www/res/screen/android/screen-mdpi-portrait.png" />
+        <splash density="port-hdpi" src="www/res/screen/android/screen-hdpi-portrait.png" />
+        <splash density="port-xhdpi" src="www/res/screen/android/screen-xhdpi-portrait.png" />
+        <splash density="port-xxhdpi" src="www/res/screen/android/screen-xxhdpi-portrait.png" />
+        <splash density="port-xxxhdpi" src="www/res/screen/android/screen-xxxhdpi-portrait.png" />
+    </platform>
+    <platform name="ios">
+        <plugin name="cordova-sqlite-evcore-extbuild-free" spec="^0.9.8" />
+        <resource-file src="www/res/icon/ios/usfm_22.png" />
+        <resource-file src="www/res/icon/ios/usfm_44.png" />
+        <resource-file src="www/res/icon/ios/usfm_64.png" />
+        <resource-file src="www/res/icon/ios/usfm_320.png" />
+        <resource-file src="www/res/icon/ios/usx_22.png" />
+        <resource-file src="www/res/icon/ios/usx_44.png" />
+        <resource-file src="www/res/icon/ios/usx_64.png" />
+        <resource-file src="www/res/icon/ios/usx_320.png" />
+        <config-file mode="replace" parent="UISupportedInterfaceOrientations" target="*-Info.plist">
+            <array>
+                <string>UIInterfaceOrientationPortrait</string>
+                <string>UIInterfaceOrientationLandscapeLeft</string>
+                <string>UIInterfaceOrientationLandscapeRight</string>
+            </array>
+        </config-file>
+        <config-file mode="replace" parent="UIFileSharingEnabled" target="*-Info.plist">
+            <true />
+        </config-file>
+        <config-file mode="replace" parent="ITSAppUsesNonExemptEncryption" target="*-Info.plist">
+            <false />
+        </config-file>
+        <config-file mode="replace" parent="UIRequiresFullScreen" target="*-Info.plist">
+            <false />
+        </config-file>
+        <config-file mode="replace" parent="NSBluetoothAlwaysUsageDescription" target="*-Info.plist">
+            <string>This app requires bluetooth access for AirDrop document export.</string>
+        </config-file>
+        <config-file mode="replace" parent="LSSupportsOpeningDocumentsInPlace" target="*-Info.plist">
+            <true />
+        </config-file>
+        <config-file mode="replace" parent="CFBundleDocumentTypes" target="*-Info.plist">
+            <array>
+                <dict>
+                    <key>CFBundleTypeIconFiles</key>
+                    <array />
+                    <key>CFBundleTypeName</key>
+                    <string>Text File</string>
+                    <key>CFBundleTypeRole</key>
+                    <string>Editor</string>
+                    <key>LSHandlerRank</key>
+                    <string>Owner</string>
+                    <key>LSItemContentTypes</key>
+                    <array>
+                        <string>public.plain-text</string>
+                    </array>
+                </dict>
+                <dict>
+                    <key>CFBundleTypeIconFiles</key>
+                    <array />
+                    <key>CFBundleTypeName</key>
+                    <string>Adapt It XML File</string>
+                    <key>CFBundleTypeRole</key>
+                    <string>Editor</string>
+                    <key>LSHandlerRank</key>
+                    <string>Owner</string>
+                    <key>LSItemContentTypes</key>
+                    <array>
+                        <string>public.xml</string>
+                    </array>
+                </dict>
+                <dict>
+                    <key>CFBundleTypeIconFiles</key>
+                    <array>
+                        <string>usfm_22.png</string>
+                        <string>usfm_44.png</string>
+                        <string>usfm_64.png</string>
+                        <string>usfm_320.png</string>
+                    </array>
+                    <key>CFBundleTypeName</key>
+                    <string>USFM Document</string>
+                    <key>CFBundleTypeRole</key>
+                    <string>Editor</string>
+                    <key>LSHandlerRank</key>
+                    <string>Owner</string>
+                    <key>LSItemContentTypes</key>
+                    <array>
+                        <string>org.ubs.document.usfm</string>
+                        <string>org.ubs.document.sfm</string>
+                    </array>
+                </dict>
+                <dict>
+                    <key>CFBundleTypeIconFiles</key>
+                    <array>
+                        <string>usx_22.png</string>
+                        <string>usx_44.png</string>
+                        <string>usx_64.png</string>
+                        <string>usx_320.png</string>
+                    </array>
+                    <key>CFBundleTypeName</key>
+                    <string>USX Document</string>
+                    <key>CFBundleTypeRole</key>
+                    <string>Editor</string>
+                    <key>LSHandlerRank</key>
+                    <string>Owner</string>
+                    <key>LSItemContentTypes</key>
+                    <array>
+                        <string>org.ubs.document.usx</string>
+                    </array>
+                </dict>
+            </array>
+        </config-file>
+        <config-file mode="replace" parent="UTImportedTypeDeclarations" target="*-Info.plist">
+            <array>
+                <dict>
+                    <key>UTTypeConformsTo</key>
+                    <array>
+                        <string>public.text</string>
+                    </array>
+                    <key>UTTypeDescription</key>
+                    <string>USFM Document</string>
+                    <key>CFBundleTypeIconFiles</key>
+                    <array />
+                    <key>UTTypeIdentifier</key>
+                    <string>org.ubs.document.usfm</string>
+                    <key>UTTypeTagSpecification</key>
+                    <dict>
+                        <key>public.filename-extension</key>
+                        <array>
+                            <string>usfm</string>
+                            <string>sfm</string>
+                        </array>
+                        <key>public.mime-type</key>
+                        <string>text/*</string>
+                    </dict>
+                </dict>
+                <dict>
+                    <key>UTTypeConformsTo</key>
+                    <array>
+                        <string>public.xml</string>
+                    </array>
+                    <key>UTTypeDescription</key>
+                    <string>USX Document</string>
+                    <key>UTTypeIconFiles</key>
+                    <array />
+                    <key>UTTypeIdentifier</key>
+                    <string>org.ubs.document.usx</string>
+                    <key>UTTypeTagSpecification</key>
+                    <dict>
+                        <key>public.filename-extension</key>
+                        <array>
+                            <string>usx</string>
+                        </array>
+                        <key>public.mime-type</key>
+                        <string>text/xml</string>
+                    </dict>
+                </dict>
+            </array>
+        </config-file>
+        <preference name="Orientation" value="all" />
+        <preference name="BackupWebStorage" value="cloud" />
+        <preference name="HideKeyboardFormAccessoryBar" value="true" />
+        <preference name="KeyboardShrinksView" value="true" />
+        <preference name="scheme" value="app" />
+        <preference name="hostname" value="localhost" />
+        <icon height="57" src="www/res/icon/ios/icon.png" width="57" />
+        <icon height="114" src="www/res/icon/ios/icon@2x.png" width="114" />
+        <icon height="60" src="www/res/icon/ios/icon-60.png" width="60" />
+        <icon height="120" src="www/res/icon/ios/icon-60@2x.png" width="120" />
+        <icon height="180" src="www/res/icon/ios/icon-60@3x.png" width="180" />
+        <icon height="72" src="www/res/icon/ios/icon-72.png" width="72" />
+        <icon height="144" src="www/res/icon/ios/icon-72@2x.png" width="144" />
+        <icon height="76" src="www/res/icon/ios/icon-76.png" width="76" />
+        <icon height="152" src="www/res/icon/ios/icon-76@2x.png" width="152" />
+        <icon height="167" src="www/res/icon/ios/icon-83@2x.png" width="167" />
+        <icon height="29" src="www/res/icon/ios/icon-small.png" width="29" />
+        <icon height="58" src="www/res/icon/ios/icon-small@2x.png" width="58" />
+        <icon height="87" src="www/res/icon/ios/icon-small@3x.png" width="87" />
+        <icon height="40" src="www/res/icon/ios/icon-40.png" width="40" />
+        <icon height="80" src="www/res/icon/ios/icon-40@2x.png" width="80" />
+        <icon height="50" src="www/res/icon/ios/icon-50.png" width="50" />
+        <icon height="100" src="www/res/icon/ios/icon-50@2x.png" width="100" />
+        <splash src="www/res/screen/ios/Default@2x~universal~anyany.png" />
+    </platform>
+    <platform name="browser">
+        <preference name="res/icon/electron/icon.png" />
+        <preference name="SplashScreen" value="res/screen/ios/Default@2x~universal~anyany.png" />
+        <preference name="AutoHideSplashScreen" value="true" />
+        <preference name="SplashScreenDelay" value="3000" />
+        <preference name="SplashScreenBackgroundColor" value="#2595cb" />
+        <preference name="ShowSplashScreen" value="false" />
+        <preference name="SplashScreenWidth" value="600" />
+        <preference name="SplashScreenHeight" value="300" />
+    </platform>
+    <platform name="electron">
+        <plugin name="cordova-sqlite-evcore-extbuild-free" spec="^0.9.8" />
+        <preference name="www/res/icon/electron/icon.png" />
+        <preference name="www/res/icon/electron/icon@2x.png" target="installer" />
+    </platform>
+    <platform name="windows">
+        <plugin name="cordova-sqlite-evcore-extbuild-free" spec="^0.9.8" />
+        <plugin name="cordova-plugin-statusbar" spec="^2.4.3" />
+        <preference name="WindowsStoreDisplayName" value="Adapt It Mobile" />
+        <preference name="StatusBarOverlaysWebView" value="true" />
+        <icon src="www/res/icon/windows/storelogo.png" target="StoreLogo" />
+        <icon src="www/res/icon/windows/Square30x30Logo.png" target="Square30x30Logo" />
+        <icon src="www/res/icon/windows/Square44x44Logo.png" target="Square44x44Logo" />
+        <icon src="www/res/icon/windows/Square70x70Logo.png" target="Square70x70Logo" />
+        <icon src="www/res/icon/windows/Square71x71Logo.png" target="Square71x71Logo" />
+        <icon src="www/res/icon/windows/Square150x150Logo.png" target="Square150x150Logo" />
+        <icon src="www/res/icon/windows/Square310x310Logo.png" target="Square310x310Logo" />
+        <icon src="www/res/icon/windows/Wide310x150Logo.png" target="Wide310x150Logo" />
+        <splash src="www/res/screen/windows/splashscreen.png" target="SplashScreen" />
+    </platform>
+    <plugin name="cordova-plugin-device" spec="^2.0.3" />
+    <plugin name="cordova-plugin-dialogs" spec="^2.0.2" />
+    <plugin name="cordova-plugin-file" spec="^6.0.2" />
+    <plugin name="cordova-plugin-fonts" spec="^0.6.5" />
+    <plugin name="cordova-plugin-keyboard" spec="https://github.com/sinn1/cordova-plugin-keyboard.git" />
+    <plugin name="cordova-plugin-x-socialsharing" spec="5.4.0" />
+    <plugin name="cordova-plugin-whitelist" spec="^1.3.4" />
+    <plugin name="cordova.plugins.diagnostic" spec="^4.0.10" />
+    <plugin name="cordova-plugin-network-information" spec="^2.0.2" />
+    <plugin name="phonegap-plugin-mobile-accessibility" spec="https://github.com/phonegap/phonegap-mobile-accessibility.git" />
+    <plugin name="cordova-clipboard" spec="https://github.com/ihadeed/cordova-clipboard.git" />
+    <engine name="android" />
+</widget>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,48 +1,30 @@
 // Gulpfile for Adapt It Mobile builds
 var gulp = require("gulp"),
-    fs = require("fs"),
-    path = require("path"),
-    exec = require("child_process").exec,
-    cordova = require("cordova-lib").cordova,
-    buildDir = path.join(process.cwd(), 'platforms'),
-    pluginDir = path.join(process.cwd(), 'plugins'),
-    buildArgs = {
-        android: ["--release", "--device", "--gradleArg=--no-daemon"],
-        ios: ["--release", "--device"],
-        windows: ["--release", "--device"],
-        wp8: ["--release", "--device"]
-    };
+    cordova = require("cordova-lib").cordova;
 
-gulp.task("default", ["build"], function () {
+gulp.task("build-android", function (done) {
+    cordova.build({
+        "platforms": ["android"],
+        "options": {
+            argv: ["--release", "-d", "--buildConfig=build.json", "--gradleArg=--no-daemon"]
+        }
+    }, done());
+});
+
+gulp.task("build-ios", function (done) {
+    cordova.build({
+        "platforms": ["ios"],
+        "options": {
+            argv: ["--release", "-d", "--buildConfig=build.json", "--device"]
+        }
+    }, done());
+});
+
+gulp.task("build", gulp.parallel("build-android", "build-ios"));
+
+gulp.task("default", gulp.series("build"), function () {
     // Copy results to bin folder
     gulp.src("platforms/android/ant-build/*.apk").pipe(gulp.dest("bin/release/android"));   // Ant build
     gulp.src("platforms/android/bin/*.apk").pipe(gulp.dest("bin/release/android"));         // Gradle build
     gulp.src("platforms/ios/build/device/*.ipa").pipe(gulp.dest("bin/release/ios"));
-});
-
-gulp.task("build", ["build-android", "build-ios"]);
-
-gulp.task("build-android", function () {
-    cordova.platforms("add", "android");
-    return gulp.src('dist')
-        .pipe(cordova.clean("android"))
-        .pipe(cordova.build("android", buildArgs));
-});
-
-gulp.task("build-ios", function () {
-    cordova.platforms("add", "ios");
-    return gulp.src('dist')
-        .pipe(cordova.clean("ios"))
-        .pipe(cordova.build("ios", buildArgs));
-});
-
-gulp.task("build-win", function () {
-    cordova.platforms("add", "windows");
-    return gulp.src('dist')
-        .pipe(cordova.clean("windows"))
-        .pipe(cordova.build("windows", buildArgs));
-});
-
-gulp.task("package", ["build"], function () {
-    return cordova.packageProject(platformsToBuild);
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@ gulp.task("build-android", function (done) {
     cordova.build({
         "platforms": ["android"],
         "options": {
-            argv: ["--release", "-d", "--buildConfig=build.json", "--gradleArg=--no-daemon"]
+            argv: ["--release", "--verbose", "--buildConfig=build.json", "--gradleArg=--no-daemon"]
         }
     }, done());
 });
@@ -15,7 +15,7 @@ gulp.task("build-ios", function (done) {
     cordova.build({
         "platforms": ["ios"],
         "options": {
-            argv: ["--release", "-d", "--buildConfig=build.json", "--device"]
+            argv: ["--release", "--verbose", "--buildConfig=build.json", "--device"]
         }
     }, done());
 });
@@ -24,7 +24,6 @@ gulp.task("build", gulp.parallel("build-android", "build-ios"));
 
 gulp.task("default", gulp.series("build"), function () {
     // Copy results to bin folder
-    gulp.src("platforms/android/ant-build/*.apk").pipe(gulp.dest("bin/release/android"));   // Ant build
-    gulp.src("platforms/android/bin/*.apk").pipe(gulp.dest("bin/release/android"));         // Gradle build
+    gulp.src("platforms/android/app/build/output/apk/release/*.apk").pipe(gulp.dest("bin/release/android"));         // Gradle build
     gulp.src("platforms/ios/build/device/*.ipa").pipe(gulp.dest("bin/release/ios"));
 });

--- a/hooks/after_prepare/uglify.js
+++ b/hooks/after_prepare/uglify.js
@@ -1,0 +1,131 @@
+module.exports = function (ctx) {
+    "use strict";
+
+    var fs = require('fs'),
+        path = require('path'),
+        UglifyJS = require('uglify-js'),
+        CleanCSS = require('clean-css'),
+        ngAnnotate = require('ng-annotate'),
+        rootDir = ctx.opts.projectRoot,
+        platforms = ctx.opts.cordova.platforms,
+        cliCommand = ctx.cmdLine,
+        configFilePath = path.join(rootDir, 'hooks/uglify-config.json'),
+        hookConfig = JSON.parse(fs.readFileSync(configFilePath)),
+        isRelease = hookConfig.alwaysRun || (cliCommand.indexOf('--release') > -1),
+        recursiveFolderSearch = hookConfig.recursiveFolderSearch, // set this to false to manually indicate the folders to process
+        foldersToProcess = hookConfig.foldersToProcess, // add other www folders in here if needed (ex. js/controllers)
+        cssMinifier = new CleanCSS(hookConfig.cleanCssOptions);
+
+
+    /**
+     * Compresses file.
+     * @param  {string} file - File path
+     * @return {undefined}
+     */
+    function compress(file) {
+        var ext = path.extname(file),
+            res,
+            source,
+            result;
+
+        switch (ext) {
+        case '.js':
+            console.log('uglifying js file ' + file);
+
+            res = ngAnnotate(String(fs.readFileSync(file, 'utf8')), {
+                add: true
+            });
+            result = UglifyJS.minify(res.src, hookConfig.uglifyJsOptions);
+            fs.writeFileSync(file, result.code, 'utf8'); // overwrite the original unminified file
+            break;
+
+        case '.css':
+            console.log('minifying css file ' + file);
+
+            source = fs.readFileSync(file, 'utf8');
+            result = cssMinifier.minify(source);
+            fs.writeFileSync(file, result.styles, 'utf8'); // overwrite the original unminified file
+            break;
+
+        default:
+            console.log('encountered a ' + ext + ' file, not compressing it');
+            break;
+        }
+    }
+
+    /**
+     * Processes files in directories.
+     * @param  {string} dir - Directory path
+     * @return {undefined}
+     */
+    function processFiles(dir) {
+        fs.readdir(dir, function (err, list) {
+            if (err) {
+                console.log('processFiles err: ' + err);
+
+                return;
+            }
+
+            list.forEach(function (file) {
+                file = path.join(dir, file);
+
+                fs.stat(file, function (err, stat) {
+                    if (stat.isFile()) {
+                        compress(file);
+                        return;
+                    }
+
+                    if (recursiveFolderSearch && stat.isDirectory()) {
+                        processFiles(file);
+                        return;
+                    }
+                });
+            });
+        });
+    }
+
+
+    /**
+     * Processes defined folders.
+     * @param  {string} wwwPath - Path to www directory
+     * @return {undefined}
+     */
+    function processFolders(wwwPath) {
+        foldersToProcess.forEach(function (folder) {
+            processFiles(path.join(wwwPath, folder));
+        });
+    }
+    
+    
+    if (!isRelease) {
+        return;
+    }
+    
+    platforms.forEach(function (platform) {
+        var wwwPath,
+            platformPath = ctx.opts.projectRoot;
+
+        switch (platform) {
+        case 'android':
+            wwwPath = path.join(platformPath, 'platforms', platform, 'assets', 'www');
+            if (!fs.existsSync(wwwPath)) {
+                wwwPath = path.join(platformPath, 'platforms', platform, 'app', 'src', 'main', 'assets', 'www');
+            }
+            break;
+
+        case 'ios':
+        case 'browser':
+        case 'wp8':
+        case 'windows':
+            wwwPath = path.join(platformPath, 'platforms', platform, 'www');
+            break;
+
+        default:
+            console.log('this hook only supports android, ios, wp8, windows, and browser currently');
+            return;
+        }
+
+        processFolders(wwwPath);
+    });
+    
+};

--- a/hooks/uglify-config.json
+++ b/hooks/uglify-config.json
@@ -1,0 +1,20 @@
+{
+    "alwaysRun": false,
+    "recursiveFolderSearch": true,
+    "foldersToProcess": [
+        "js",
+        "css"
+    ],
+    "uglifyJsOptions": {
+        "compress": {
+            "drop_console": true
+        },
+        "mangle": false,
+        "output": {
+            "code": true
+        }
+    },
+    "cleanCssOptions": {
+        "specialComments": "all"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -17,19 +17,15 @@
     "adaptation"
   ],
   "devDependencies": {
+    "cordova-android": "^9.0.0",
+    "cordova-ios": "^6.1.1",
     "fs": "0.0.2",
-    "gulp": "^3.9.1",
-    "gulp-cordova-build-android": "^1.3.0",
-    "gulp-cordova-build-ios": "^1.0.0",
-    "gulp-cordova-create": "^1.2.0",
-    "gulp-cordova-plugin": "^1.4.0",
+    "gulp": "^4.0.2",
     "path": "^0.12.7",
-    "plist": "^1.2.0"
+    "plist": "^3.0.1"
   },
   "dependencies": {
-    "cordova-android": "^9.0.0",
     "cordova-clipboard": "https://github.com/ihadeed/cordova-clipboard.git",
-    "cordova-ios": "^6.1.1",
     "cordova-lib": "^8.0.0",
     "cordova-plugin-device": "^2.0.3",
     "cordova-plugin-dialogs": "^2.0.2",
@@ -43,6 +39,7 @@
     "cordova-plugin-x-socialsharing": "5.4.0",
     "cordova-sqlite-evcore-extbuild-free": "^0.9.8",
     "cordova.plugins.diagnostic": "^4.0.10",
+    "npx": "^10.2.2",
     "phonegap-plugin-mobile-accessibility": "https://github.com/phonegap/phonegap-mobile-accessibility.git"
   },
   "bugs": {
@@ -84,7 +81,6 @@
       "cordova-plugin-splashscreen": {}
     },
     "platforms": [
-      "android",
       "ios"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "cordova-android": "^9.0.0",
     "cordova-ios": "^6.1.1",
+    "cordova-uglify": "^0.3.4",
     "fs": "0.0.2",
     "gulp": "^4.0.2",
     "path": "^0.12.7",
@@ -39,6 +40,7 @@
     "cordova-plugin-x-socialsharing": "5.4.0",
     "cordova-sqlite-evcore-extbuild-free": "^0.9.8",
     "cordova.plugins.diagnostic": "^4.0.10",
+    "gulp-uglify": "^3.0.2",
     "npx": "^10.2.2",
     "phonegap-plugin-mobile-accessibility": "https://github.com/phonegap/phonegap-mobile-accessibility.git"
   },
@@ -81,7 +83,7 @@
       "cordova-plugin-splashscreen": {}
     },
     "platforms": [
-      "ios"
+      "android"
     ]
   }
 }

--- a/www/js/models/json/book.js
+++ b/www/js/models/json/book.js
@@ -9,7 +9,7 @@ define(function (require) {
 
         Book = Backbone.Model.extend({
 
-            urlRoot: "http://localhost:3000/book"
+            urlRoot: "/book"
 
         }),
 
@@ -17,7 +17,7 @@ define(function (require) {
 
             model: Book,
 
-            url: "http://localhost:3000/books"
+            url: "/books"
 
         });
 

--- a/www/js/models/json/chapter.js
+++ b/www/js/models/json/chapter.js
@@ -9,7 +9,7 @@ define(function (require) {
 
         Chapter = Backbone.Model.extend({
 
-            urlRoot: "http://localhost:3000/chapter"
+            urlRoot: "/chapter"
 
         }),
 
@@ -17,7 +17,7 @@ define(function (require) {
 
             model: Chapter,
 
-            url: "http://localhost:3000/chapters"
+            url: "/chapters"
 
         });
 

--- a/www/js/models/json/project.js
+++ b/www/js/models/json/project.js
@@ -9,7 +9,7 @@ define(function (require) {
 
         Project = Backbone.Model.extend({
 
-            urlRoot: "http://localhost:3000/project"
+            urlRoot: "/project"
 
         }),
 
@@ -17,7 +17,7 @@ define(function (require) {
 
             model: Project,
 
-            url: "http://localhost:3000/projects"
+            url: "/projects"
 
         });
 

--- a/www/js/models/json/sourcephrase.js
+++ b/www/js/models/json/sourcephrase.js
@@ -9,7 +9,7 @@ define(function (require) {
 
         SourcePhrase = Backbone.Model.extend({
 
-            urlRoot: "http://localhost:3000/sp"
+            urlRoot: "/sp"
 
         }),
 
@@ -17,7 +17,7 @@ define(function (require) {
 
             model: SourcePhrase,
 
-            url: "http://localhost:3000/sps"
+            url: "/sps"
 
         });
 

--- a/www/js/models/json/targetunit.js
+++ b/www/js/models/json/targetunit.js
@@ -9,7 +9,7 @@ define(function (require) {
 
         TargetUnit = Backbone.Model.extend({
 
-            urlRoot: "http://localhost:3000/targetunit"
+            urlRoot: "/targetunit"
 
         }),
 
@@ -17,7 +17,7 @@ define(function (require) {
 
             model: TargetUnit,
 
-            url: "http://localhost:3000/targetunits"
+            url: "/targetunits"
 
         });
 


### PR DESCRIPTION
Fixes #411 (migrate from PhoneGap Build service).

This adds the following:
- Support for building using gulpjs. Build tasks can be found in gulpfile.js (the call "gulp" will compile both Android and iOS)
- Support for release builds found in build.json. You'll need to add a file "../certs/aim.keystore" - and fill in the password info in the build.json file.
- Support for "uglify"-ing (compressing) the javascript files once the files are copied over to the platforms subdirectory (i.e., this doesn't compress the code you're working on in the www directory). This reduces the overall app file size.

@adapt-it/developers
