### PR TITLE
Add warning to source/target language settings page

### DIFF
--- a/www/js/views/ProjectViews.js
+++ b/www/js/views/ProjectViews.js
@@ -1464,6 +1464,17 @@ define(function (require) {
                     break;
                 }
                 this.container.show(currentView);
+                if (number === 1 || number === 2) {
+                    // the source and target language pages normally wouldn't be messed with once they're set up;
+                    // it's possible that the user needs to correct something in the dialect? At any rate, tell the user
+                    // that new projects can be created in the settings / manage projects page.
+                    if (navigator.notification) {
+                        navigator.notification.alert(i18n.t('view.dscWarnChangeProject'));
+                    } else {
+                        alert(i18n.t('view.dscWarnChangeProject'));
+                    }
+                    
+                }
             }
         }),
 

--- a/www/locales/dev/translation.json
+++ b/www/locales/dev/translation.json
@@ -321,6 +321,7 @@
         "ttlEditorUI": "Editor and User Interface",
         "ttlManageProjects": "Manage Projects",
         "ttlCurrentProjectSettings": "Current Project Settings",
+        "dscWarnChangeProject": "Note: Do not modify the project's source and target language to create a new project. New projects can be created in the Manage Projects page (Settings > Manage Projects).",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/dev/translation.json
+++ b/www/locales/dev/translation.json
@@ -321,7 +321,7 @@
         "ttlEditorUI": "Editor and User Interface",
         "ttlManageProjects": "Manage Projects",
         "ttlCurrentProjectSettings": "Current Project Settings",
-        "dscWarnChangeProject": "Note: Do not modify the project's source and target language to create a new project. New projects can be created in the Manage Projects page (Settings > Manage Projects).",
+        "dscWarnChangeProject": "Do not modify the project's source and target language to create a new project. New projects can be created in the Manage Projects page (Settings > Manage Projects).",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/en/translation.json
+++ b/www/locales/en/translation.json
@@ -321,6 +321,7 @@
         "ttlEditorUI": "Editor and User Interface",
         "ttlManageProjects": "Manage Projects",
         "ttlCurrentProjectSettings": "Current Project Settings",
+        "dscWarnChangeProject": "Note: Do not modify the project's source and target language to create a new project. New projects can be created in the Manage Projects page (Settings > Manage Projects).",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/en/translation.json
+++ b/www/locales/en/translation.json
@@ -321,7 +321,7 @@
         "ttlEditorUI": "Editor and User Interface",
         "ttlManageProjects": "Manage Projects",
         "ttlCurrentProjectSettings": "Current Project Settings",
-        "dscWarnChangeProject": "Note: Do not modify the project's source and target language to create a new project. New projects can be created in the Manage Projects page (Settings > Manage Projects).",
+        "dscWarnChangeProject": "Do not modify the project's source and target language to create a new project. New projects can be created in the Manage Projects page (Settings > Manage Projects).",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/es/translation.json
+++ b/www/locales/es/translation.json
@@ -321,6 +321,7 @@
         "ttlEditorUI": "Editor e interfaz de usuario",
         "ttlManageProjects": "Administrar Proyectos",
         "ttlCurrentProjectSettings": "Configuración del proyecto actual",
+        "dscWarnChangeProject": "Nota: No modifique el idioma de origen y de destino del proyecto para crear un nuevo proyecto. Se pueden crear nuevos proyectos en la página Administrar Proyectos (Configuración> Administrar Proyectos).",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/es/translation.json
+++ b/www/locales/es/translation.json
@@ -321,7 +321,7 @@
         "ttlEditorUI": "Editor e interfaz de usuario",
         "ttlManageProjects": "Administrar Proyectos",
         "ttlCurrentProjectSettings": "Configuración del proyecto actual",
-        "dscWarnChangeProject": "Nota: No modifique el idioma de origen y de destino del proyecto para crear un nuevo proyecto. Se pueden crear nuevos proyectos en la página Administrar Proyectos (Configuración> Administrar Proyectos).",
+        "dscWarnChangeProject": "No modifique el idioma de origen y de destino del proyecto para crear un nuevo proyecto. Se pueden crear nuevos proyectos en la página Administrar Proyectos (Configuración> Administrar Proyectos).",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/fr/translation.json
+++ b/www/locales/fr/translation.json
@@ -321,6 +321,7 @@
         "ttlEditorUI": "Editeur et interface utilisateur",
         "ttlManageProjects": "Administrer les projets",
         "ttlCurrentProjectSettings": "Paramètres du projet actuel",
+        "dscWarnChangeProject": "Remarque: ne modifiez pas la langue source et cible du projet pour créer un nouveau projet. De nouveaux projets peuvent être créés dans la page Administrer les projets (Paramètres> Administrer les projets).",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/fr/translation.json
+++ b/www/locales/fr/translation.json
@@ -321,7 +321,7 @@
         "ttlEditorUI": "Editeur et interface utilisateur",
         "ttlManageProjects": "Administrer les projets",
         "ttlCurrentProjectSettings": "Paramètres du projet actuel",
-        "dscWarnChangeProject": "Remarque: ne modifiez pas la langue source et cible du projet pour créer un nouveau projet. De nouveaux projets peuvent être créés dans la page Administrer les projets (Paramètres> Administrer les projets).",
+        "dscWarnChangeProject": "ne modifiez pas la langue source et cible du projet pour créer un nouveau projet. De nouveaux projets peuvent être créés dans la page Administrer les projets (Paramètres> Administrer les projets).",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/hi/translation.json
+++ b/www/locales/hi/translation.json
@@ -320,6 +320,7 @@
         "ttlEditorUI": "Editor and User Interface",
         "ttlManageProjects": "Manage Projects",
         "ttlCurrentProjectSettings": "Current Project Settings",
+        "dscWarnChangeProject": "Note: Do not modify the project's source and target language to create a new project. New projects can be created in the Manage Projects page (Settings > Manage Projects).",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/hi/translation.json
+++ b/www/locales/hi/translation.json
@@ -320,7 +320,7 @@
         "ttlEditorUI": "Editor and User Interface",
         "ttlManageProjects": "Manage Projects",
         "ttlCurrentProjectSettings": "Current Project Settings",
-        "dscWarnChangeProject": "Note: Do not modify the project's source and target language to create a new project. New projects can be created in the Manage Projects page (Settings > Manage Projects).",
+        "dscWarnChangeProject": "Do not modify the project's source and target language to create a new project. New projects can be created in the Manage Projects page (Settings > Manage Projects).",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/pt/translation.json
+++ b/www/locales/pt/translation.json
@@ -322,7 +322,7 @@
         "ttlEditorUI": "Editor e interface do usuário",
         "ttlManageProjects": "Administrar Projetos",
         "ttlCurrentProjectSettings": "Configurações para o projeto atual",
-        "dscWarnChangeProject": "Nota: Não modifique o idioma de origem e de destino do projeto para criar um novo projeto. Novos projetos podem ser criados na página Administrar Projetos (Configurações> Administrar Projetos).",
+        "dscWarnChangeProject": "Não modifique o idioma de origem e de destino do projeto para criar um novo projeto. Novos projetos podem ser criados na página Administrar Projetos (Configurações> Administrar Projetos).",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/pt/translation.json
+++ b/www/locales/pt/translation.json
@@ -322,6 +322,7 @@
         "ttlEditorUI": "Editor e interface do usuário",
         "ttlManageProjects": "Administrar Projetos",
         "ttlCurrentProjectSettings": "Configurações para o projeto atual",
+        "dscWarnChangeProject": "Nota: Não modifique o idioma de origem e de destino do projeto para criar um novo projeto. Novos projetos podem ser criados na página Administrar Projetos (Configurações> Administrar Projetos).",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/tpi/translation.json
+++ b/www/locales/tpi/translation.json
@@ -318,6 +318,7 @@
         "ttlEditorUI": "Editor and User Interface",
         "ttlManageProjects": "Manage Projects",
         "ttlCurrentProjectSettings": "Current Project Settings",
+        "dscWarnChangeProject": "Note: Do not modify the project's source and target language to create a new project. New projects can be created in the Manage Projects page (Settings > Manage Projects).",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/tpi/translation.json
+++ b/www/locales/tpi/translation.json
@@ -318,7 +318,7 @@
         "ttlEditorUI": "Editor and User Interface",
         "ttlManageProjects": "Manage Projects",
         "ttlCurrentProjectSettings": "Current Project Settings",
-        "dscWarnChangeProject": "Note: Do not modify the project's source and target language to create a new project. New projects can be created in the Manage Projects page (Settings > Manage Projects).",
+        "dscWarnChangeProject": "Do not modify the project's source and target language to create a new project. New projects can be created in the Manage Projects page (Settings > Manage Projects).",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {


### PR DESCRIPTION
Fixes #359  .

Here we're not completely disallowing users from changing the source or target language / dialect, in the off chance that they need to correct something that was in error (the language code getting an update, or the language name being offensive and needing to be fixed, etc.). 

Instead, AIM now gives a warning to _not_ change the source and target language to create a new translation project, and directs them to the proper place to create a new project (Settings > Manage Projects).

@adapt-it/developers
