### PR TITLE
Prep 1.5.0 release

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -99,6 +99,8 @@
         <resource-file src="www/res/icon/ios/usx_44.png" />
         <resource-file src="www/res/icon/ios/usx_64.png" />
         <resource-file src="www/res/icon/ios/usx_320.png" />
+        <!-- EDB 8/16/21 TODO: config-file items are up to date, but some icon files do need to be
+        manually copied over into the XCode project before releasing. -->
         <config-file mode="replace" parent="UISupportedInterfaceOrientations" target="*-Info.plist">
             <array>
                 <string>UIInterfaceOrientationPortrait</string>
@@ -119,7 +121,7 @@
             <string>This app requires bluetooth access for AirDrop document export.</string>
         </config-file>
         <config-file mode="replace" parent="LSSupportsOpeningDocumentsInPlace" target="*-Info.plist">
-            <true />
+            <false />
         </config-file>
         <config-file mode="replace" parent="CFBundleDocumentTypes" target="*-Info.plist">
             <array>

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cordova-plugin-dialogs": "^2.0.2",
     "cordova-plugin-file": "^6.0.2",
     "cordova-plugin-filepath": "^1.6.0",
+    "cordova-plugin-keyboard": "git+https://github.com/sinn1/cordova-plugin-keyboard.git",
     "cordova-plugin-network-information": "^3.0.0",
     "cordova-plugin-x-socialsharing": "^6.0.3",
     "cordova-sqlite-evcore-extbuild-free": "^0.15.1",
@@ -40,7 +41,6 @@
     "cordova-clipboard": "https://github.com/ihadeed/cordova-clipboard.git",
     "cordova-lib": "^10.0.0",
     "cordova-plugin-fonts": "^0.6.5",
-    "cordova-plugin-keyboard": "git+https://github.com/sinn1/cordova-plugin-keyboard.git",
     "cordova-plugin-splashscreen": "^6.0.0",
     "cordova-plugin-statusbar": "^2.4.3",
     "gulp-uglify": "^3.0.2",
@@ -70,7 +70,6 @@
       "cordova-plugin-fonts": {},
       "phonegap-plugin-mobile-accessibility": {},
       "cordova-clipboard": {},
-      "cordova-plugin-keyboard": {},
       "cordova-plugin-statusbar": {},
       "cordova-plugin-splashscreen": {},
       "cordova-plugin-device": {},
@@ -88,7 +87,8 @@
         "ANDROID_SCHEME": " ",
         "ANDROID_HOST": " ",
         "ANDROID_PATHPREFIX": "/"
-      }
+      },
+      "cordova-plugin-keyboard": {}
     },
     "platforms": [
       "ios",

--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -79,7 +79,7 @@ define(function (require) {
             usingImportedKB: false,
             version: "1.5.0", // appended with milestone / iOS build info
             AndroidBuild: "34", // (was milestone release #)
-            iOSBuild: "1.5.0",
+            iOSBuild: "1.5.1",
             importingURL: "", // for other apps in Android-land sending us files to import
 
             // Mimics Element.scrollIntoView({"block": "center", "behavior": "smooth"}) for


### PR DESCRIPTION
A couple changes:

- bump iOS build (first iOS submission was missing a couple App Store icons)
- incorporate fix for #442 
- Turn off in-place editing support for iOS (we don't have the privs to do so)

