### PR TITLE
Fix #518

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="44" defaultlocale="en" id="org.adaptit.adaptitmobile" ios-CFBundleVersion="1" version="1.12.1" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:gap="http://phonegap.com/ns/1.0">
+<widget android-versionCode="45" defaultlocale="en" id="org.adaptit.adaptitmobile" ios-CFBundleVersion="1" version="1.12.2" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:gap="http://phonegap.com/ns/1.0">
     <name short="Adapt It Mobile" xml:lang="en">Adapt It Mobile</name>
     <description xml:lang="en">
         An open source application for translating between related languages.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "cordova-android": "^12.0.1",
     "cordova-clipboard": "github:ihadeed/cordova-clipboard",
-    "cordova-ios": "^7.0.0",
+    "cordova-ios": "^7.0.1",
     "cordova-plugin-customurlscheme": "^5.0.2",
     "cordova-plugin-device": "^2.0.3",
     "cordova-plugin-dialogs": "^2.0.2",
@@ -94,8 +94,8 @@
       "cordova-plugin-file": {}
     },
     "platforms": [
-      "ios",
-      "android"
+      "android",
+      "ios"
     ]
   }
 }

--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -78,8 +78,8 @@ define(function (require) {
             searchIndex: 0,
             currentProject: null,
             localURLs: [],
-            version: "1.12.1", // appended with Android / iOS build info
-            AndroidBuild: "44", // (was milestone release #)
+            version: "1.12.2", // appended with Android / iOS build info
+            AndroidBuild: "45", // (was milestone release #)
             iOSBuild: "1", // iOS uploaded build number for this release (increments from 1 for each release) 
             importingURL: "", // for other apps in Android-land sending us files to import
 
@@ -562,13 +562,17 @@ define(function (require) {
             
             lookupChapter: function (id) {
                 console.log("lookupChapter");
-                var proj = this.ProjectList.where({projectid: id});
-                if (proj !== null) {
-                    lookupView = new SearchViews.LookupView({model: proj[0]});
-                    window.Application.main.show(lookupView);
-                } else {
-                    console.log("no project defined");
-                }
+                $.when(window.Application.ProjectList.fetch({reset: true, data: {name: ""}})).done(function () {
+                    $.when(window.Application.ChapterList.fetch({reset: true, data: {name: ""}})).done(function () {
+                        var proj = window.Application.ProjectList.where({projectid: id});
+                        if (proj !== null) {
+                            lookupView = new SearchViews.LookupView({model: proj[0]});
+                            window.Application.main.show(lookupView);
+                        } else {
+                            console.log("no project defined");
+                        }
+                    });
+                });
             },
 
             adaptChapter: function (id) {

--- a/www/js/models/sql/chapter.js
+++ b/www/js/models/sql/chapter.js
@@ -49,10 +49,11 @@ define(function (require) {
                 var sql = "INSERT INTO chapter (chapterid,bookid,projectid,name,lastadapted,versecount) VALUES (?,?,?,?,?,?);";
                 window.Application.db.transaction(function (tx) {
                     tx.executeSql(sql, [attributes.chapterid, attributes.bookid, attributes.projectid, attributes.name, attributes.lastadapted, attributes.versecount], function (tx, res) {
+                        // console.log ("** CHAPTER INSERT: " + attributes.name);
                         attributes.id = res.insertId;
 //                        console.log("INSERT ok: " + res.toString());
                     }, function (tx, err) {
-                        console.log("INSERT (create) error: " + err.message);
+                        console.log("CHAPTER INSERT (create) error: " + err.message);
                     });
                 });
             },
@@ -60,10 +61,11 @@ define(function (require) {
                 var attributes = this.attributes;
                 var sql = 'UPDATE chapter SET bookid=?, projectid=?, name=?, lastadapted=?, versecount=? WHERE chapterid=?;';
                 window.Application.db.transaction(function (tx) {
+                    // console.log ("** CHAPTER UPDATE: " + attributes.name);
                     tx.executeSql(sql, [attributes.bookid, attributes.projectid, attributes.name, attributes.lastadapted, attributes.versecount, attributes.chapterid], function (tx, res) {
 //                        console.log("UPDATE ok: " + res.toString());
                     }, function (tx, err) {
-                        console.log("UPDATE error: " + err.message);
+                        console.log("CHAPTER UPDATE error: " + err.message);
                     });
                 });
             },
@@ -72,7 +74,7 @@ define(function (require) {
                     tx.executeSql("DELETE FROM chapter WHERE chapterid=?;", [this.attributes.chapterid], function (tx, res) {
 //                        console.log("DELETE ok: " + res.toString());
                     }, function (tx, err) {
-                        console.log("DELETE error: " + err.message);
+                        console.log("CHAPTER DELETE error: " + err.message);
                     });
                 });
             },

--- a/www/js/views/DocumentViews.js
+++ b/www/js/views/DocumentViews.js
@@ -2958,6 +2958,7 @@ define(function (require) {
                                     // verify that the chapters have been created (this is for pre-1.6.0 imports)
                                     if (numChaps !== book.get('chapters').length) {
                                         // create empty chapters (i.e. with no verses) that are missing in our book
+                                        // NOTE that the chapter objects are saved at the end of the USFM import
                                         for (i=book.get('chapters').length; i < numChaps; i++) {
                                             chapterName = i18n.t("view.lblChapterName", {bookName: bookName, chapterNumber: (i + 1)});
                                             // does this chapter name exist?
@@ -2973,8 +2974,7 @@ define(function (require) {
                                                     lastadapted: 0,
                                                     versecount: 0
                                                 });
-                                                chapters.add(chapter);                            
-                                                chapter.save();
+                                                chapters.add(chapter);
                                             }
                                         }
                                         // update the book chapter array
@@ -3005,6 +3005,7 @@ define(function (require) {
                     } else {
                         // new import -- create the book object, with all the chapter objects 
                         // (with zero verses for now; they are populated below)
+                        // NOTE that the chapter objects are saved at the end of the USFM import
                         bookID = window.Application.generateUUID();
                         book = new bookModel.Book({
                             bookid: bookID,
@@ -3028,7 +3029,6 @@ define(function (require) {
                                 versecount: 0
                             });
                             chapters.add(chapter);
-                            chapter.save();
                         }
                         // update the chapters in our book
                         book.set('chapters', chaps, {silent: true});
@@ -3047,6 +3047,7 @@ define(function (require) {
                                 contents = contents.replace(contents.substring(0, index - 1), "");
                             }
                         }
+                        // resolve -- don't need to add a confirm dialog
                         defer.resolve("new import / no confirm needed");
                     }
 
@@ -3763,7 +3764,12 @@ define(function (require) {
                         if (chapter.get('versecount') < verseCount) {
                             // only update if we're increasing the verse count
                             chapter.set('versecount', verseCount, {silent: true});
-                            chapter.save();
+                        }
+                        // now save all the chapters
+                        for (i=0; i < numChaps; i++) {
+                            chapterID = book.get("chapters")[i]; // get next chapterID of the book we're importing
+                            chapter = chapters.where({chapterid: chapterID})[0]; // chapter object from chapters list
+                            chapter.save(); // save it (could be INSERT or UPDATE operation)
                         }
 
                         // add any remaining sourcephrases


### PR DESCRIPTION
Fixes #518  .

Changes proposed in this request:

- Move chapter.save() calls to the end of USFM import (avoids multiple INSERT calls per chapter)
- Ignore content before \c tag for imports that don't contain chapter 1
- refresh contents collection before displaying lookupView (browse/search view)

@adapt-it/developers
