### PR TITLE
KB editor

### DIFF
--- a/hooks/uglify-config.json
+++ b/hooks/uglify-config.json
@@ -1,20 +1,17 @@
 {
-    "alwaysRun": false,
-    "recursiveFolderSearch": true,
-    "foldersToProcess": [
-        "js",
-        "css"
-    ],
-    "uglifyJsOptions": {
-        "compress": {
-            "drop_console": true
-        },
-        "mangle": false,
-        "output": {
-            "code": true
-        }
+  "alwaysRun": false,
+  "recursiveFolderSearch": true,
+  "foldersToProcess": ["js", "css", "build"],
+  "uglifyJsOptions": {
+    "compress": {
+      "drop_console": true
     },
-    "cleanCssOptions": {
-        "specialComments": "all"
+    "mangle": false,
+    "output": {
+      "code": true
     }
+  },
+  "cleanCssOptions": {
+    "specialComments": "all"
+  }
 }

--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -31,6 +31,7 @@ define(function (require) {
         importDocView   = null,
         exportDocView   = null,
         showTransView   = null,
+        newTransView    = null,
         editTUView      = null,
         i18n            = require('i18n'),
         lang            = "",
@@ -442,42 +443,45 @@ define(function (require) {
                 });
             },
 
-            showTU: function (id) {
+            newTU: function() {
+                console.log("newTU");
+                // update the KB list, then show the view
+                $.when(window.Application.kbList.fetch({reset: true, data: {projectid: window.Application.currentProject.get("projectid")}})).done(function () {
+                    // create a new / temporary TU to pass in to the TUView
+                    // (this object isn't saved or added to the collection yet)
+                    var newID = window.Application.generateUUID(),
+                        curDate = new Date(),
+                        timestamp = (curDate.getFullYear() + "-" + (curDate.getMonth() + 1) + "-" + curDate.getDay() + "T" + curDate.getUTCHours() + ":" + curDate.getUTCMinutes() + ":" + curDate.getUTCSeconds() + "z"),
+                        theTU = new kbModels.TargetUnit({
+                            tuid: newID,
+                            projectid: window.Application.currentProject.get("projectid"),
+                            source: "",
+                            refstring: [],
+                            timestamp: timestamp,
+                            user: "",
+                            isGloss: 0
+                        });
+                    newTransView = new SearchViews.NewTUView({model: theTU});
+                    newTransView.delegateEvents();
+                    window.Application.main.show(newTransView);
+                });
+            },
+
+            editTU: function (id) {
                 console.log("editTU");
                 // update the KB list, then show the view
-                $.when(window.Application.kbList.fetch({reset: true, data: {projectid: id}})).done(function () {
-                    var theTU = null,
-                        bNewTU = false;
-                    // are we creating a new TU?
-                    if (id === "000") {
-                        // create a new / temporary TU to pass in to the TUView
-                        // (this object isn't saved or added to the collection yet)
-                        var newID = window.Application.generateUUID(),
-                            curDate = new Date(),
-                            timestamp = (curDate.getFullYear() + "-" + (curDate.getMonth() + 1) + "-" + curDate.getDay() + "T" + curDate.getUTCHours() + ":" + curDate.getUTCMinutes() + ":" + curDate.getUTCSeconds() + "z"),
-                            theTU = new kbModels.TargetUnit({
-                                tuid: newID,
-                                projectid: id,
-                                source: "",
-                                refstring: [],
-                                timestamp: timestamp,
-                                user: "",
-                                isGloss: 0
-                            });
-                        bNewTU = true;
-                    } else {
-                        // show the selected TU
-                        var tu = window.Application.kbList.where({tuid: id});
-                        if (tu === null) {
-                            console.log("KB Entry not found:" + id);
-                            return; // don't do anything -- this TU is supposed to exist
-                        }
-                        theTU = tu[0];
-                        bNewTU = false;
+                $.when(window.Application.kbList.fetch({reset: true, data: {projectid: window.Application.currentProject.get("projectid")}})).done(function () {
+                    var theTU = null;
+                    // show the selected TU
+                    var tu = window.Application.kbList.where({tuid: id});
+                    if (tu === null) {
+                        console.log("KB Entry not found:" + id);
+                        return; // don't do anything -- this TU is supposed to exist
                     }
+                    theTU = tu[0];
                     showTransView = new SearchViews.TUView({model: theTU});
                     showTransView.spObj = null; // NO current sourcephrase (this is coming from the KB editor)
-                    showTransView.bNewTU = bNewTU; // set the bNewTU flag as appropriate
+                    showTransView.bNewTU = false;
                     showTransView.delegateEvents();
                     window.Application.main.show(showTransView);
                 });

--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -333,7 +333,16 @@ define(function (require) {
                 // this.checkDBSchema();
             },
             
+            checkDBSchema: function () {
+                // verify we're on the latest DB schema (upgrade if necessary)
+                return projModel.checkSchema();
+            },
+
+            // -----------
             // Routes from AppRouter (router.js)
+            // -----------
+
+            // Home page (main view)
             home: function () {
                 // First, look for projects in the project list that aren't complete;
                 // this can happen if the user clicks the back button before completing the 
@@ -396,18 +405,13 @@ define(function (require) {
                     }
                 });
             },
-            
-            checkDBSchema: function () {
-                // verify we're on the latest DB schema (upgrade if necessary)
-                return projModel.checkSchema();
-            },
-            
+            // Set UI language view (language can also be set within project settings / edit project view > UI settings)
             setUILanguage: function () {
                 langView = new HomeViews.UILanguageView();
                 langView.delegateEvents();
                 window.Application.main.show(langView);
             },
-
+            // Edit project view
             editProject: function (id) {
                 // edit the selected project
                 var proj = this.ProjectList.where({projectid: id});
@@ -415,7 +419,7 @@ define(function (require) {
                     window.Application.main.show(new ProjectViews.EditProjectView({model: proj[0]}));
                 }
             },
-
+            // Copy project view
             copyProject: function () {
                 var proj = new projModel.Project();
                 copyProjectView = new ProjectViews.CopyProjectView({model: proj});
@@ -423,7 +427,7 @@ define(function (require) {
                 this.ProjectList.add(proj);
                 this.main.show(copyProjectView);
             },
-            
+            // New Project view (wizard)
             newProject: function () {
                 var proj = new projModel.Project();
                 newProjectView = new ProjectViews.NewProjectView({model: proj});
@@ -431,28 +435,23 @@ define(function (require) {
                 this.ProjectList.add(proj);
                 this.main.show(newProjectView);
             },
-
+            // KB editor view
             editKB: function (id) {
                 console.log("editKB");
-                // update the KB and source Phrase lists, then show the KB editor view
-                $.when(window.Application.kbList.fetch({reset: true, data: {projectid: id}})).done(function () {
-                    var proj = window.Application.ProjectList.where({projectid: id});
-                    editTUView = new SearchViews.TUListView({model: proj[0]});
-                    editTUView.delegateEvents();
-                    window.Application.main.show(editTUView);
-                });
+                // show the KB editor view (KB refresh happens inside the view's onShow())
+                var proj = window.Application.ProjectList.where({projectid: id});
+                editTUView = new SearchViews.TUListView({model: proj[0]});
+                editTUView.delegateEvents();
+                window.Application.main.show(editTUView);
             },
-
+            // New Target Unit view
             newTU: function() {
                 console.log("newTU");
-                // update the KB list, then show the view
-                $.when(window.Application.kbList.fetch({reset: true, data: {projectid: window.Application.currentProject.get("projectid")}})).done(function () {
-                    newTransView = new SearchViews.NewTUView();
-                    newTransView.delegateEvents();
-                    window.Application.main.show(newTransView);
-                });
+                newTransView = new SearchViews.NewTUView();
+                newTransView.delegateEvents();
+                window.Application.main.show(newTransView);
             },
-
+            // View / edit TU
             editTU: function (id) {
                 console.log("editTU");
                 // update the KB list, then show the view
@@ -472,7 +471,7 @@ define(function (require) {
                     window.Application.main.show(showTransView);
                 });
             },
-
+            // Show translations (edit TU, but also includes the "current translation" / SP)
             showTranslations: function (id) {
                 console.log("showTranslations");
                 // update the KB and source phrase list, then display the Translations screen with the currently-selected sourcephrase
@@ -535,43 +534,7 @@ define(function (require) {
                     });
                 });
             },
-
-            // Another process has sent us a file via URL. Get the File handle and send it along to
-            // importFileFromURL (below).
-            processFileEntry: function (fileEntry) {
-                console.log("processFileEntry: enter");
-                fileEntry.file(window.Application.importFileFromURL, window.Application.importFail);
-            },
-
-            processError: function (error) {
-                // log the error and continue processing
-                console.log("getDirectory error: " + error.code);
-                alert("error: " + error.code);
-            },
-
-            // This is similar to importBooks, EXCEPT that another process is sending a file to us to
-            // open/import (rather than the user picking a file out of a list). Call
-            // ImportDocumentView::importFile() to import the file.
-            importFileFromURL: function (file) {
-                console.log("importFile: enter");
-                var proj = window.Application.currentProject;
-                if (proj !== null) {
-                    // We have a project -- load the ImportDocumentView to do the work
-                    importDocView = new DocumentViews.ImportDocumentView({model: proj});
-                    importDocView.isLoadingFromURL = true;
-                    importDocView.delegateEvents();
-                    window.Application.main.show(importDocView);
-                    // call ImportDocumentView::importFromURL() to import the file
-                    importDocView.importFromURL(file, proj);
-                } else {
-                    alert("No current project defined -- ignoring open() call");
-                }
-            },
-
-            importFail: function () {
-                alert("Unable to open file.");
-            },
-            
+            // import doc view
             importBooks: function (id) {
                 console.log("importBooks");
                 // update the book and chapter lists, then show the import docs view
@@ -583,7 +546,7 @@ define(function (require) {
                     window.Application.main.show(importDocView);
                 }
             },
-
+            // Export doc view
             exportBooks: function (id) {
                 console.log("exportBooks");
                 var proj = window.Application.currentProject;
@@ -595,7 +558,7 @@ define(function (require) {
                     window.Application.main.show(exportDocView);
                 }
             },
-            
+            // Search / browse chapter view
             lookupChapter: function (id) {
                 console.log("lookupChapter");
                 $.when(window.Application.ProjectList.fetch({reset: true, data: {name: ""}})).done(function () {
@@ -610,7 +573,7 @@ define(function (require) {
                     });
                 });
             },
-
+            // Adapt View (the reason we're here)
             adaptChapter: function (id) {
                 console.log("adaptChapter");
                 // refresh the models
@@ -649,6 +612,44 @@ define(function (require) {
                         }
                     });
                 });
+            },
+            // ----
+            // External document route helper methods:
+            // Another process has sent us a file via URL.
+            // ----
+            // Helper method to get the File handle from the external process and send it along to
+            // importFileFromURL (below).
+            processFileEntry: function (fileEntry) {
+                console.log("processFileEntry: enter");
+                fileEntry.file(window.Application.importFileFromURL, window.Application.importFail);
+            },
+            // helper callback to process a getDirectory() error
+            processError: function (error) {
+                // log the error and continue processing
+                console.log("getDirectory error: " + error.code);
+                alert("error: " + error.code);
+            },
+            // This is similar to importBooks, EXCEPT that another process is sending a file to us to
+            // open/import (rather than the user picking a file out of a list). Call
+            // ImportDocumentView::importFile() to import the file.
+            importFileFromURL: function (file) {
+                console.log("importFile: enter");
+                var proj = window.Application.currentProject;
+                if (proj !== null) {
+                    // We have a project -- load the ImportDocumentView to do the work
+                    importDocView = new DocumentViews.ImportDocumentView({model: proj});
+                    importDocView.isLoadingFromURL = true;
+                    importDocView.delegateEvents();
+                    window.Application.main.show(importDocView);
+                    // call ImportDocumentView::importFromURL() to import the file
+                    importDocView.importFromURL(file, proj);
+                } else {
+                    alert("No current project defined -- ignoring open() call");
+                }
+            },
+            // Helper callback for processFileEntry() failure (above)
+            importFail: function () {
+                alert("Unable to open file.");
             }
         });
     

--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -454,28 +454,25 @@ define(function (require) {
             // View / edit TU
             editTU: function (id) {
                 console.log("editTU");
-                // update the KB list, then show the view
-                $.when(window.Application.kbList.fetch({reset: true, data: {projectid: window.Application.currentProject.get("projectid")}})).done(function () {
-                    var theTU = null;
-                    // show the selected TU
-                    var tu = window.Application.kbList.where({tuid: id});
-                    if (tu === null) {
-                        console.log("KB Entry not found:" + id);
-                        return; // don't do anything -- this TU is supposed to exist
-                    }
-                    theTU = tu[0];
-                    showTransView = new SearchViews.TUView({model: theTU});
-                    showTransView.spObj = null; // NO current sourcephrase (this is coming from the KB editor)
-                    showTransView.bNewTU = false;
-                    showTransView.delegateEvents();
-                    window.Application.main.show(showTransView);
-                });
+                var theTU = null;
+                // show the selected TU
+                var tu = window.Application.kbList.where({tuid: id});
+                if (tu === null) {
+                    console.log("KB Entry not found:" + id);
+                    return; // don't do anything -- this TU is supposed to exist
+                }
+                theTU = tu[0];
+                showTransView = new SearchViews.TUView({model: theTU});
+                showTransView.spObj = null; // NO current sourcephrase (this is coming from the KB editor)
+                showTransView.bNewTU = false;
+                showTransView.delegateEvents();
+                window.Application.main.show(showTransView);
             },
             // Show translations (edit TU, but also includes the "current translation" / SP)
             showTranslations: function (id) {
                 console.log("showTranslations");
                 // update the KB and source phrase list, then display the Translations screen with the currently-selected sourcephrase
-                $.when(window.Application.kbList.fetch({reset: true, data: {projectid: window.Application.currentProject.get('projectid')}})).done(function () {
+                $.when(window.Application.kbList.fetch({reset: true, data: {projectid: window.Application.currentProject.get('projectid'), isGloss: 0}})).done(function () {
                     $.when(window.Application.spList.fetch({reset: true, data: {spid: window.Application.currentProject.get('lastAdaptedSPID')}})).done(function () {
                         var sp = window.Application.spList.where({spid: id});
                         if (sp === null || sp.length === 0) {

--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -447,21 +447,7 @@ define(function (require) {
                 console.log("newTU");
                 // update the KB list, then show the view
                 $.when(window.Application.kbList.fetch({reset: true, data: {projectid: window.Application.currentProject.get("projectid")}})).done(function () {
-                    // create a new / temporary TU to pass in to the TUView
-                    // (this object isn't saved or added to the collection yet)
-                    var newID = window.Application.generateUUID(),
-                        curDate = new Date(),
-                        timestamp = (curDate.getFullYear() + "-" + (curDate.getMonth() + 1) + "-" + curDate.getDay() + "T" + curDate.getUTCHours() + ":" + curDate.getUTCMinutes() + ":" + curDate.getUTCSeconds() + "z"),
-                        theTU = new kbModels.TargetUnit({
-                            tuid: newID,
-                            projectid: window.Application.currentProject.get("projectid"),
-                            source: "",
-                            refstring: [],
-                            timestamp: timestamp,
-                            user: "",
-                            isGloss: 0
-                        });
-                    newTransView = new SearchViews.NewTUView({model: theTU});
+                    newTransView = new SearchViews.NewTUView();
                     newTransView.delegateEvents();
                     window.Application.main.show(newTransView);
                 });

--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -441,17 +441,25 @@ define(function (require) {
                     window.Application.main.show(editTUView);
                 });
             },
-            
-            editTU: function (id) {
+
+            showTU: function (id) {
                 console.log("editTU");
                 // update the KB list, then show the view
                 $.when(window.Application.kbList.fetch({reset: true, data: {projectid: id}})).done(function () {
-                    // show the selected TU
-                    var tu = window.Application.kbList.where({tuid: id});
-                    if (tu === null) {
-                        console.log("KB Entry not found:" + id);
+                    var theTU = null;
+                    // are we creating a new TU?
+                    if (id === "000") {
+                        theTU = null;
+                    } else {
+                        // show the selected TU
+                        var tu = window.Application.kbList.where({tuid: id});
+                        if (tu === null) {
+                            console.log("KB Entry not found:" + id);
+                            return; // don't do anything -- this TU is supposed to exist
+                        }
+                        theTU = tu[0];
                     }
-                    showTransView = new SearchViews.TUView({model: tu[0]});
+                    showTransView = new SearchViews.TUView({model: theTU});
                     showTransView.spObj = null; // NO current sourcephrase (this is coming from the KB editor)
                     showTransView.delegateEvents();
                     window.Application.main.show(showTransView);

--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -446,10 +446,25 @@ define(function (require) {
                 console.log("editTU");
                 // update the KB list, then show the view
                 $.when(window.Application.kbList.fetch({reset: true, data: {projectid: id}})).done(function () {
-                    var theTU = null;
+                    var theTU = null,
+                        bNewTU = false;
                     // are we creating a new TU?
                     if (id === "000") {
-                        theTU = null;
+                        // create a new / temporary TU to pass in to the TUView
+                        // (this object isn't saved or added to the collection yet)
+                        var newID = window.Application.generateUUID(),
+                            curDate = new Date(),
+                            timestamp = (curDate.getFullYear() + "-" + (curDate.getMonth() + 1) + "-" + curDate.getDay() + "T" + curDate.getUTCHours() + ":" + curDate.getUTCMinutes() + ":" + curDate.getUTCSeconds() + "z"),
+                            theTU = new kbModels.TargetUnit({
+                                tuid: newID,
+                                projectid: id,
+                                source: "",
+                                refstring: [],
+                                timestamp: timestamp,
+                                user: "",
+                                isGloss: 0
+                            });
+                        bNewTU = true;
                     } else {
                         // show the selected TU
                         var tu = window.Application.kbList.where({tuid: id});
@@ -458,9 +473,11 @@ define(function (require) {
                             return; // don't do anything -- this TU is supposed to exist
                         }
                         theTU = tu[0];
+                        bNewTU = false;
                     }
                     showTransView = new SearchViews.TUView({model: theTU});
                     showTransView.spObj = null; // NO current sourcephrase (this is coming from the KB editor)
+                    showTransView.bNewTU = bNewTU; // set the bNewTU flag as appropriate
                     showTransView.delegateEvents();
                     window.Application.main.show(showTransView);
                 });

--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -463,14 +463,16 @@ define(function (require) {
                 // update the KB and source phrase list, then display the Translations screen with the currently-selected sourcephrase
                 $.when(window.Application.kbList.fetch({reset: true, data: {projectid: window.Application.currentProject.get('projectid')}})).done(function () {
                     $.when(window.Application.spList.fetch({reset: true, data: {spid: window.Application.currentProject.get('lastAdaptedSPID')}})).done(function () {
-                        var tu = window.Application.kbList.where({tuid: id});
-                        if (tu === null) {
-                            console.log("KB Entry not found:" + id);
+                        var sp = window.Application.spList.where({spid: id});
+                        if (sp === null || sp.length === 0) {
+                            console.log("sp Entry not found:" + id);
+                        } else {
+                            var tu = window.Application.kbList.findWhere({'source': sp[0].get("source").toLowerCase(), 'isGloss': 0});
+                            showTransView = new SearchViews.TUView({model: tu});
+                            showTransView.spObj = sp[0];
+                            showTransView.delegateEvents();
+                            window.Application.main.show(showTransView);    
                         }
-                        showTransView = new SearchViews.TUView({model: tu[0]});
-                        showTransView.spObj = window.Application.spList[0];
-                        showTransView.delegateEvents();
-                        window.Application.main.show(showTransView);
                     });
                 });
             },

--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -31,7 +31,7 @@ define(function (require) {
         importDocView   = null,
         exportDocView   = null,
         showTransView   = null,
-        editKBView      = null,
+        editTUView      = null,
         i18n            = require('i18n'),
         lang            = "",
         models          = [],
@@ -436,22 +436,38 @@ define(function (require) {
                 // update the KB and source Phrase lists, then show the KB editor view
                 $.when(window.Application.kbList.fetch({reset: true, data: {projectid: id}})).done(function () {
                     var proj = window.Application.ProjectList.where({projectid: id});
-                    editKBView = new SearchViews.KBListView({model: proj[0]});
-                    editKBView.delegateEvents();
-                    window.Application.main.show(editKBView);
+                    editTUView = new SearchViews.TUListView({model: proj[0]});
+                    editTUView.delegateEvents();
+                    window.Application.main.show(editTUView);
                 });
             },
             
-            lookupKB: function (id) {
-                console.log("lookupKB");
-                // update the KB and source phrase list, then display the Show Translations screen
+            editTU: function (id) {
+                console.log("editTU");
+                // update the KB list, then show the view
+                $.when(window.Application.kbList.fetch({reset: true, data: {projectid: id}})).done(function () {
+                    // show the selected TU
+                    var tu = window.Application.kbList.where({tuid: id});
+                    if (tu === null) {
+                        console.log("KB Entry not found:" + id);
+                    }
+                    showTransView = new SearchViews.TUView({model: tu[0]});
+                    showTransView.spObj = null; // NO current sourcephrase (this is coming from the KB editor)
+                    showTransView.delegateEvents();
+                    window.Application.main.show(showTransView);
+                });
+            },
+
+            showTranslations: function (id) {
+                console.log("showTranslations");
+                // update the KB and source phrase list, then display the Translations screen with the currently-selected sourcephrase
                 $.when(window.Application.kbList.fetch({reset: true, data: {projectid: window.Application.currentProject.get('projectid')}})).done(function () {
                     $.when(window.Application.spList.fetch({reset: true, data: {spid: window.Application.currentProject.get('lastAdaptedSPID')}})).done(function () {
                         var tu = window.Application.kbList.where({tuid: id});
                         if (tu === null) {
                             console.log("KB Entry not found:" + id);
                         }
-                        showTransView = new SearchViews.KBView({model: tu[0]});
+                        showTransView = new SearchViews.TUView({model: tu[0]});
                         showTransView.spObj = window.Application.spList[0];
                         showTransView.delegateEvents();
                         window.Application.main.show(showTransView);

--- a/www/js/models/sql/targetunit.js
+++ b/www/js/models/sql/targetunit.js
@@ -270,7 +270,7 @@ define(function (require) {
                             options.success(data);
                         });
                     } else if (options.data.hasOwnProperty('projectid')) {
-                         projectid = options.data.projectid;
+                        projectid = options.data.projectid;
                         results = targetunits.filter(function (element) {
                             return element.attributes.projectid === projectid.toLowerCase();
                         });
@@ -308,11 +308,6 @@ define(function (require) {
                         return deferred.promise();
                     } else if (options.data.hasOwnProperty('source')) {
                         var source = options.data.source;
-                        // special case -- empty source query ==> reset local copy so we force a retrieve
-                        // from the database
-                        if (source === "") {
-                            targetunits.length = 0;
-                        }
                         results = targetunits.filter(function (element) {
                             return element.attributes.source.toLowerCase().indexOf(source.toLowerCase()) > -1;
                         });
@@ -351,6 +346,11 @@ define(function (require) {
                         }
                         // return the promise
                         return deferred.promise();
+                    } else {
+                        results = targetunits;
+                        // results already in collection -- return them
+                        options.success(results);
+                        deferred.resolve(results);
                     }
                 } else if (method === "delete") {
                     if (options.data.hasOwnProperty('projectid')) {

--- a/www/js/models/sql/targetunit.js
+++ b/www/js/models/sql/targetunit.js
@@ -168,6 +168,13 @@ define(function (require) {
                 });
             },
 
+            // Remove just the local targetunits from the collection --
+            // this keeps the in-memory objects to a minimum
+            clearLocal: function () {
+                console.log("targetunitCollection clearLocal() - entry");
+                targetunits.length = 0;
+            },
+
             // removes all targetunits for the specified projectid
             // This is done when the user is restoring from a KB file to clean out what's currently in the DB
             clearKBForProject: function (projectid, isGloss) {

--- a/www/js/router.js
+++ b/www/js/router.js
@@ -18,8 +18,9 @@ define(function (require) {
             "project":      "newProject",       // #project
             "project/:id":  "editProject",      // #project/projectID
             "search/:id":   "lookupChapter",    // #search/projectID
-            "kb/:id":       "editKB",           // #kb/projectID () 
-            "tu/:tuid":     "lookupKB",         // #tu/target unit ID (view / edit the target unit)
+            "kb/:id":       "editKB",           // #kb/projectID (KB editor)
+            "tu/:tuid":     "editTU",           // #tu/target unit ID (TU editor)
+            "sp/:spid":     "showTranslations", // #sp/source phrase ID (show translations for SP)
             "import/:id":   "importBooks",      // #import/projectID (import books into projectID)
             "export/:id":   "exportBooks",      // #export/projectID (export books from projectID)
             "adapt/:chapterid":    "adaptChapter"      // #adapt/chapterID (adapt chapterID)

--- a/www/js/router.js
+++ b/www/js/router.js
@@ -19,7 +19,8 @@ define(function (require) {
             "project/:id":  "editProject",      // #project/projectID
             "search/:id":   "lookupChapter",    // #search/projectID
             "kb/:id":       "editKB",           // #kb/projectID (KB editor)
-            "tu/:tuid":     "showTU",           // #tu/target unit ID (TU editor - ID will be "000" for a new TU)
+            "tu":           "newTU",            // #tu (create a new TU)
+            "tu/:tuid":     "editTU",           // #tu/target unit ID (TU editor)
             "sp/:spid":     "showTranslations", // #sp/source phrase ID (show translations for SP)
             "import/:id":   "importBooks",      // #import/projectID (import books into projectID)
             "export/:id":   "exportBooks",      // #export/projectID (export books from projectID)

--- a/www/js/router.js
+++ b/www/js/router.js
@@ -19,7 +19,7 @@ define(function (require) {
             "project/:id":  "editProject",      // #project/projectID
             "search/:id":   "lookupChapter",    // #search/projectID
             "kb/:id":       "editKB",           // #kb/projectID (KB editor)
-            "tu/:tuid":     "editTU",           // #tu/target unit ID (TU editor)
+            "tu/:tuid":     "showTU",           // #tu/target unit ID (TU editor - ID will be "000" for a new TU)
             "sp/:spid":     "showTranslations", // #sp/source phrase ID (show translations for SP)
             "import/:id":   "importBooks",      // #import/projectID (import books into projectID)
             "export/:id":   "exportBooks",      // #export/projectID (export books from projectID)

--- a/www/js/views/AdaptViews.js
+++ b/www/js/views/AdaptViews.js
@@ -655,6 +655,7 @@ define(function (require) {
                                         // found the target char -- build the auto-capped string and place in the
                                         // result array
                                         result.push(caseTarget[targetIdx].charAt(1) + target[optionsIdx].substr(1));
+                                        break; // inner for loop
                                     }
                                 }
                             }
@@ -2220,6 +2221,7 @@ define(function (require) {
                         refstrings = tu.get('refstring');
                         // first, make sure these refstrings are actually being used
                         options.length = 0; // clear out any old cruft
+                        KBtarget.length = 0;
                         for (i = 0; i < refstrings.length; i++) {
                             if (refstrings[i].n > 0) {
                                 options.push(Underscore.unescape(refstrings[i].target));
@@ -2400,6 +2402,7 @@ define(function (require) {
                                 refstrings = tu.get('refstring');
                                 // first, make sure these refstrings are actually being used
                                 options.length = 0; // clear out any old cruft
+                                KBtarget.length = 0;
                                 for (i = 0; i < refstrings.length; i++) {
                                     if (refstrings[i].n > 0) {
                                         options.push(Underscore.unescape(refstrings[i].target));
@@ -2539,6 +2542,7 @@ define(function (require) {
                         refstrings = tu.get('refstring');
                         // first, make sure these refstrings are actually being used
                         options.length = 0; // clear out any old cruft
+                        KBtarget.length = 0;
                         for (i = 0; i < refstrings.length; i++) {
                             if (refstrings[i].n > 0) {
                                 options.push(Underscore.unescape(refstrings[i].target));
@@ -2714,6 +2718,7 @@ define(function (require) {
                                 refstrings = tu.get('refstring');
                                 // first, make sure these refstrings are actually being used
                                 options.length = 0; // clear out any old cruft
+                                KBtarget.length = 0;
                                 for (i = 0; i < refstrings.length; i++) {
                                     if (refstrings[i].n > 0) {
                                         options.push(Underscore.unescape(refstrings[i].target));

--- a/www/js/views/AdaptViews.js
+++ b/www/js/views/AdaptViews.js
@@ -461,6 +461,10 @@ define(function (require) {
                             $("#SearchRS").html(searchRS);
                             $("#SearchIndex").html("(" + (window.Application.searchIndex + 1) + "/" + window.Application.searchList.length + ")");
                         }
+                        // disable editing blank verses if needed
+                        if (this.allowEditBlankSP === false) {
+                            $(".nosource").prop('contenteditable', false); // no source -- set target to read-only
+                        }
                         if (project.get('lastAdaptedSPID').length > 0) {
                             // not searching, but there is a sourcephrase ID from our last session -- select it now
                             isSelecting = true;
@@ -503,10 +507,6 @@ define(function (require) {
                     if (selectedStart !== null) {
                         $("#mnuTranslations").removeClass("menu-disabled");
                         $("#mnuFindRS").removeClass("menu-disabled");
-                    }
-                    // disable editing blank verses if needed
-                    if (this.allowEditBlankSP === false) {
-                        $(".nosource").prop('contenteditable', false); // no source -- set target to read-only
                     }
                     // hide gloss / free translation lines if needed
                     if (this.ShowGlossFT === false) {

--- a/www/js/views/AdaptViews.js
+++ b/www/js/views/AdaptViews.js
@@ -3165,24 +3165,15 @@ define(function (require) {
                 }
             },
 
-            // User clicked the Show Translations button -- find the selection in the KB and
-            // navigate to that page
+            // User clicked the Show Translations button -- find the source phrase and
+            // navigate to the show translations page
             showTranslations: function () {
-                var tu = null;
-                var tuid = "";
-                var sourceValue = this.stripPunctuation(this.autoRemoveCaps($(selectedStart).children('.source').html(), true), true);
-                var projectid = project.get('projectid');
-                // find the selection and TUID
-                var elts = kblist.filter(function (element) {
-                    return (element.attributes.projectid === projectid && element.attributes.source === sourceValue);
-                });
-                if (elts.length > 0) {
-                    tu = elts[0];
-                }
-                if (tu) {
-                    // found something for this element -- navigate to the KB editor
-                    tuid = tu.get('tuid');
-                    window.Application.router.navigate("tu/" + tuid, {trigger: true, replace: true});
+                var strID = $(selectedStart).attr('id');
+                strID = strID.substr(strID.indexOf("-") + 1); // remove "pile-"
+                var selectedObj = this.collection.findWhere({spid: strID});
+                if (selectedObj) {
+                    // found something for this element -- navigate to the SP editor
+                    window.Application.router.navigate("sp/" + strID, {trigger: true, replace: true});
                 }
             },
             // User clicked on the Preview (toggle) button -- enable or disable

--- a/www/js/views/DocumentViews.js
+++ b/www/js/views/DocumentViews.js
@@ -6499,8 +6499,9 @@ define(function (require) {
                     caseTarget.push(elt.t);
                 });
                 // fetch the KB in case we import an AI XML document (we'll populate the KB if that happens)
+                window.Application.kbList.clearLocal(); // clear out the kbList so it gets rebuilt
                 kblist = window.Application.kbList;
-                kblist.fetch({reset: true, data: {source: ""}});
+                kblist.fetch({reset: true, data: {projectid: window.Application.currentProject.get("projectid")}});
                 // reset the isKB flag
                 isKB = false;
                 isGlossKB = false;

--- a/www/js/views/SearchViews.js
+++ b/www/js/views/SearchViews.js
@@ -110,8 +110,10 @@ define(function (require) {
 
             },
             events: {
-                "click .big-link": "onClickTU"
+                "click .big-link": "onClickTU",
+                "click #btnNewTU": "onClickNewTU"
             },
+            // User clicked on a TU item from the list. Show the TUView for this item.
             onClickTU: function (event) {
                 var tuID = event.currentTarget.id;
                 var tu = this.TUList.findWhere({tuid: tuID});
@@ -120,11 +122,17 @@ define(function (require) {
                 }
 
             },
+            // User clicked on the New TU button.
+            onClickNewTU: function () {
+                console.log("onClickNewTU - entry");
 
+            },
             onShow: function () {
                 var lstTU = "";
                 var rs = null;
                 var strInfo = "";
+                // first item in list -- create a new TU
+                // lstTU += "<li class=\"topcoat-list__item\"><a class=\"big-link\" id=\"btnNewTU\"><span class=\"btn-plus\"></span>" + i18next.t("view.lblProjectSettings") + "<span class=\"chevron\"></span></a></li>";
                 this.TUList.fetch({reset: true, data: {projectid: this.model.get('projectid')}});
                 // initial sort - name
                 this.TUList.comparator = 'source';

--- a/www/js/views/SearchViews.js
+++ b/www/js/views/SearchViews.js
@@ -315,10 +315,16 @@ define(function (require) {
                 
             },
             onClickRefString: function (event) {
-                var RS_ACTIONS = "<div class=\"control-row\"><button id=\"btnRSSelect\" class=\"btnSelect\" title=\"" + i18next.t("view.lblUseTranslation") + "\"><span class=\"btn-check\" role=\"img\"></span>" + i18next.t("view.lblUseTranslation") + "</button></div><div class=\"control-row\"><button id=\"btnRSEdit\" title=\"" + i18next.t("view.lblEditTranslation") + "\" class=\"btnEdit\"><span class=\"btn-pencil\" role=\"img\"></span>" + i18next.t("view.lblEditTranslation") + "</button></div><div class=\"control-row\"><button id=\"btnRSSearch\" title=\"" + i18next.t("view.lblFindInDocuments") + "\" class=\"btnSearch\"><span class=\"btn-search\" role=\"img\"></span>" + i18next.t("view.lblFindInDocuments") + "</button></div><div id=\"rsResults\" class=\"control-group rsResults\"></div><div class=\"control-row\"><button id=\"btnRSDelete\" title=\"" + i18next.t("view.lblDeleteTranslation") + "\" class=\"btnDelete danger\"><span class=\"btn-delete\" role=\"img\"></span>" + i18next.t("view.lblDeleteTranslation") + "</button></div>",
+                var RS_ACTIONS = "",
                     RS_HIDDEN = "<div class=\"control-row\">" + i18next.t("view.dscHiddenTranslation") + "</div><div class=\"control-row\"><button id=\"btnRSRestore\" class=\"btnRestore\" title=\"" + i18next.t("view.lblRestoreTranslation") + "\"><span class=\"btn-check\" role=\"img\"></span>" + i18next.t("view.lblRestoreTranslation") + "</button></div>",
                     refstrings = this.model.get("refstring"),
                     index = event.currentTarget.id.substr(3);
+                if (this.spObj !== null) {
+                    // only add the "select this translation" if we have a current source phrase
+                    RS_ACTIONS = "<div class=\"control-row\"><button id=\"btnRSSelect\" class=\"btnSelect\" title=\"" + i18next.t("view.lblUseTranslation") + "\"><span class=\"btn-check\" role=\"img\"></span>" + i18next.t("view.lblUseTranslation") + "</button></div>";
+                }
+                // add the rest of the actions
+                RS_ACTIONS += "<div class=\"control-row\"><button id=\"btnRSEdit\" title=\"" + i18next.t("view.lblEditTranslation") + "\" class=\"btnEdit\"><span class=\"btn-pencil\" role=\"img\"></span>" + i18next.t("view.lblEditTranslation") + "</button></div><div class=\"control-row\"><button id=\"btnRSSearch\" title=\"" + i18next.t("view.lblFindInDocuments") + "\" class=\"btnSearch\"><span class=\"btn-search\" role=\"img\"></span>" + i18next.t("view.lblFindInDocuments") + "</button></div><div id=\"rsResults\" class=\"control-group rsResults\"></div><div class=\"control-row\"><button id=\"btnRSDelete\" title=\"" + i18next.t("view.lblDeleteTranslation") + "\" class=\"btnDelete danger\"><span class=\"btn-delete\" role=\"img\"></span>" + i18next.t("view.lblDeleteTranslation") + "</button></div>";
                 // Toggle the visibility of the action menu bar
                 if ($("#lia-" + index).hasClass("show")) {
                     // hide it
@@ -639,15 +645,9 @@ define(function (require) {
 //                window.Application.router.navigate("adapt/" + cid, {trigger: true});
             },
             onShow: function () {
+                // fill current translation info
                 var srcLang = window.Application.currentProject.get('SourceLanguageName');
                 var tgtLang = window.Application.currentProject.get('TargetLanguageName');
-                if (window.Application.spList.length > 0) {
-                    // found a sourcephrase -- fill out the UI
-                    var sp = window.Application.spList.at(0);
-                    $("#srcPhrase").html(sp.get("source"));
-                    $("#tgtPhrase").html(sp.get("target"));
-                }
-                // fill current translation info
                 $("#lblSourceLang").html(srcLang);
                 $("#lbltargetLang").html(tgtLang);
                 // load the source / target punctuation pairs
@@ -660,12 +660,19 @@ define(function (require) {
                     caseSource.push(elt.s);
                     caseTarget.push(elt.t);
                 });
+                // source we're looking at
+                $("#srcPhrase").html(this.model.get("source"));
+                // are we looking at a current point in the translation, or just the possible TU refstrings?
                 if (this.spObj === null) {
-                    // no spObj passed in -- we're looking at the possible translations for a target unit,
-                    // NOT the "show translations" dialog
-                    $("#curSP").hide();
-                }
-                
+                    // no spObj passed in -- we're looking at the possible refstrings for a target unit,
+                    // NOT the "show translations" dialog -- hide the current translation stuff
+                    $("#lblCurrentTrans").hide();
+                    $(".tgtbox").hide();
+                } else {
+                    // looking at a current point in the translation (i.e, the Show Translations dialog) -
+                    // show what the current translation for this sourcephrase is
+                    $("#tgtPhrase").html(this.spObj.get("target"));
+                }                
                 // display the refstrings (and their relative frequency)
                 this.showRefStrings(""); // empty param --> don't select anything
             }

--- a/www/js/views/SearchViews.js
+++ b/www/js/views/SearchViews.js
@@ -66,6 +66,7 @@ define(function (require) {
                 // model.update();
                 model.save();
                 console.log("addNewRS - saving model");
+                // redraw the UI (taken from showRefStrings() below)
                 $("#RefStrings").html(theRefStrings(refstrings));
                 // set the frequency meters for each refstring
                 for (i = 0; i < refstrings.length; i++) {
@@ -88,13 +89,6 @@ define(function (require) {
                     // now select the index we found
                     $("#rs-" + selectedIndex).click();
                 }
-                // // add the new item to the UI
-                // // (the _full_ refstring list is templated; see RefStringList.html)
-                // var liRS = "<li class=\"topcoat-list__item\" id=\"li-" + (refstrings.length - 1) + "\"><div class=\"big-link\" id='list-rs-" + (refstrings.length - 1) + "'><div id=\"rs-" + (refstrings.length - 1) + "\" class=\"chap-list__item emphasized refstring-list__item\">";
-                // liRS += strTarget + "</div><span class=\"meter-dashed right\"><span id=\"pct-" + (refstrings.length - 1) + "\" class=\"pct\"></span></span></div><div class=\"liActions\" id='lia-" + (refstrings.length - 1) + "'></div></li>";
-                // $("#RefStrings").append(liRS);
-                // // 50% width/frequency, just because
-                // $("#pct-" + (refstrings.length - 1)).width("50%");
             } else {
                 console.log("addNewRS -- item already exists, no work to do");
             }
@@ -192,11 +186,11 @@ define(function (require) {
                 if (tu) {
                     window.Application.router.navigate("tu/" + tuID, {trigger: true});
                 }
-
             },
-            // User clicked on the New TU button.
+            // User clicked on the New TU button. Show the TUView for a _new_ item, with an empty/null TU
             onClickNewTU: function () {
                 console.log("onClickNewTU - entry");
+                window.Application.router.navigate("tu/000", {trigger: true});
             },
             onShow: function () {
                 var lstTU = "";
@@ -208,6 +202,7 @@ define(function (require) {
                 // initial sort - name
                 this.TUList.comparator = 'source';
                 this.TUList.sort();
+                lstTU += "<li class=\"topcoat-list__item li-tu\"><div class=\"big-link\" id=\"btnNewTU\"><div class=\"chap-list__item emphasized refstring-list__item filter-burnt-orange\"><span class=\"img-plus-small\" style=\"padding-right: 16px;\"></span>" + i18next.t("view.lblNewTU") + "</div></div></li>";
                 this.TUList.each(function (model, index) {
                     // TODO: what to do with placeholder text? Currently filtered out here
                     if (model.get("source").length > 0) {
@@ -235,6 +230,7 @@ define(function (require) {
 
         TUView = Marionette.LayoutView.extend({
             spObj: null,
+            bNewTU: false,
             spInstances: null,
             strOldSP: "",
             bDirty: false,
@@ -743,6 +739,29 @@ define(function (require) {
 //                window.Application.router.navigate("adapt/" + cid, {trigger: true});
             },
             onShow: function () {
+                if (this.model === null) {
+                    // this.
+                    // no obj -- create a new TU
+                    // // no entry in KB with this source -- add one
+                    // var newID = window.Application.generateUUID(),
+                    //     newTU = new kbModels.TargetUnit({
+                    //         tuid: newID,
+                    //         projectid: projectid,
+                    //         source: sourceValue,
+                    //         refstring: [
+                    //             {
+                    //                 target: targetValue,
+                    //                 n: "1"
+                    //             }
+                    //         ],
+                    //         timestamp: timestamp,
+                    //         user: "",
+                    //         isGloss: isGloss
+                    //     });
+                    // kblist.add(newTU);
+                    // newTU.save();
+                    
+                }
                 // do a fuzzy search on the TargetUnit's source (i.e., no punctuation)
                 this.spList.fetch({reset: true, data: {source: this.model.get("source")}});
                 // also fill out the chapter list

--- a/www/js/views/SearchViews.js
+++ b/www/js/views/SearchViews.js
@@ -33,13 +33,14 @@ define(function (require) {
         addNewRS = function (model, strTarget) {
             var refstrings = model.get("refstring"),
                 selectedIndex = 0,
+                i = 0,
                 curDate = new Date(),
                 timestamp = (curDate.getFullYear() + "-" + (curDate.getMonth() + 1) + "-" + curDate.getDay() + "T" + curDate.getUTCHours() + ":" + curDate.getUTCMinutes() + ":" + curDate.getUTCSeconds() + "z"),
                 found = false;
             console.log("addNewRS - attempting to add: " + strTarget);
             // sanity check -- is this refstring already there?
             // add or increment the new value
-            for (var i = 0; i < refstrings.length; i++) {
+            for (i = 0; i < refstrings.length; i++) {
                 if (refstrings[i].target === strTarget) {
                     // This RefString already exists in the KB - no work to do
                     found = true;
@@ -65,6 +66,35 @@ define(function (require) {
                 // model.update();
                 model.save();
                 console.log("addNewRS - saving model");
+                $("#RefStrings").html(theRefStrings(refstrings));
+                // set the frequency meters for each refstring
+                for (i = 0; i < refstrings.length; i++) {
+                    if (strTarget.length > 0) {
+                        // looking to select a refstring after redrawing
+                        if (refstrings[i].target === strTarget) {
+                            selectedIndex = i; // found it
+                        }
+                    }
+                    if (refstrings[i].n > 0) {
+                        // normal refstring instance
+                        $("#pct-" + i).width((Math.round(refstrings[i].n / refstrings[0].n * 90) + 10) + "%");
+                    } else {
+                        // deleted refstring
+                        $("#pct-" + i).width("0%");
+                        $("#rs-" + i).addClass("deleted");
+                    }
+                }
+                if (strTarget.length > 0) {
+                    // now select the index we found
+                    $("#rs-" + selectedIndex).click();
+                }
+                // // add the new item to the UI
+                // // (the _full_ refstring list is templated; see RefStringList.html)
+                // var liRS = "<li class=\"topcoat-list__item\" id=\"li-" + (refstrings.length - 1) + "\"><div class=\"big-link\" id='list-rs-" + (refstrings.length - 1) + "'><div id=\"rs-" + (refstrings.length - 1) + "\" class=\"chap-list__item emphasized refstring-list__item\">";
+                // liRS += strTarget + "</div><span class=\"meter-dashed right\"><span id=\"pct-" + (refstrings.length - 1) + "\" class=\"pct\"></span></span></div><div class=\"liActions\" id='lia-" + (refstrings.length - 1) + "'></div></li>";
+                // $("#RefStrings").append(liRS);
+                // // 50% width/frequency, just because
+                // $("#pct-" + (refstrings.length - 1)).width("50%");
             } else {
                 console.log("addNewRS -- item already exists, no work to do");
             }
@@ -372,7 +402,6 @@ define(function (require) {
                         if (results.buttonIndex === 1) {
                             // new translation in results.input1
                             addNewRS(obj, results.input1);
-                            window.Application.router.navigate("sp/" + obj.get("spid"), {trigger: true, replace: true});
                         }
                     }, i18next.t('view.lblNewRS'));
                 } else {
@@ -381,7 +410,6 @@ define(function (require) {
                     if (result !== null) {
                         // new translation in result
                         addNewRS(this.model, result);
-                        window.Application.router.navigate("sp/" + this.model.get("spid"), {trigger: true, replace: true});
                     }
                 }
             },

--- a/www/js/views/SearchViews.js
+++ b/www/js/views/SearchViews.js
@@ -167,8 +167,6 @@ define(function (require) {
                 // spList is used for the "find in documents"
                 this.spList = new spModels.SourcePhraseCollection();
                 this.spList.clearLocal();
-                // do a fuzzy search on the TargetUnit's source (i.e., no punctuation)
-                this.spList.fetch({reset: true, data: {source: this.model.get("source")}});
                 this.render();
             },
             // set the current translation to the provided text
@@ -561,7 +559,7 @@ define(function (require) {
                 var index = event.currentTarget.parentElement.parentElement.id.substr(4);
                 var refstrings = this.model.get("refstring");
                 var src = this.model.get("source");
-                var sp = window.Application.spList.at(0);
+                var sp = this.spList.at(0);
                 var spLength = sp.get("source").length - (sp.get("prepuncts").length + sp.get("follpuncts").length);
                 var tgt = refstrings[index].target;
                 var i = 0;
@@ -645,6 +643,10 @@ define(function (require) {
 //                window.Application.router.navigate("adapt/" + cid, {trigger: true});
             },
             onShow: function () {
+                // do a fuzzy search on the TargetUnit's source (i.e., no punctuation)
+                this.spList.fetch({reset: true, data: {source: this.model.get("source")}});
+                // also fill out the chapter list
+                window.Application.ChapterList.fetch({reset: true, data: {name: ""}});
                 // fill current translation info
                 var srcLang = window.Application.currentProject.get('SourceLanguageName');
                 var tgtLang = window.Application.currentProject.get('TargetLanguageName');

--- a/www/js/views/SearchViews.js
+++ b/www/js/views/SearchViews.js
@@ -207,24 +207,30 @@ define(function (require) {
             },
             // User clicked on a TU item from the list. Show the TUView for this item.
             onClickTU: function (event) {
+                // prevent event from bubbling up
+                event.stopPropagation();
+                event.preventDefault();
                 var tuID = event.currentTarget.id;
-                var tu = this.TUList.findWhere({tuid: tuID});
+                var tu = window.Application.kbList.findWhere({tuid: tuID});
                 if (tu) {
                     window.Application.router.navigate("tu/" + tuID, {trigger: true});
                 }
             },
             // User clicked on the New TU button. Show the TUView for a _new_ item, with an empty/null TU
-            onClickNewTU: function () {
+            onClickNewTU: function (event) {
+                // prevent event from bubbling up
+                event.stopPropagation();
+                event.preventDefault();
                 console.log("onClickNewTU - entry");
                 window.Application.router.navigate("tu", {trigger: true});
             },
             // User clicked on the Previous button - retrieve the previous page of TU items
             onSearchPrevPage: function () {
                 console.log("onSearchPrevPage: entry");
-                searchCursor = searchCursor - PAGE_SIZE;
+                this.searchCursor = this.searchCursor - PAGE_SIZE;
                 // shouldn't happen, but just in case
-                if (searchCursor < 0) {
-                    searchCursor = 0;
+                if (this.searchCursor < 0) {
+                    this.searchCursor = 0;
                 }
                 var key = $('#search').val().trim(),
                     self = this,
@@ -262,7 +268,7 @@ define(function (require) {
             // User clicked the Next button -- retrieve the next page of TU items
             onSearchNextPage: function () {
                 console.log("onSearchNextPage: entry");
-                searchCursor = searchCursor + PAGE_SIZE;
+                this.searchCursor = this.searchCursor + PAGE_SIZE;
                 var key = $('#search').val().trim(),
                     self = this,
                     total = 0,
@@ -311,7 +317,7 @@ define(function (require) {
                 $("#lstTU").html("");
                 var lstTU = "";
                 // Get the first page of filtered items
-                $.when(window.Application.kbList.fetch({reset: true, data: {projectid: window.Application.currentProject.get("projectid"), isGloss: 0, limit: 100}})).done(function () {
+                $.when(window.Application.kbList.fetch({reset: true, data: {projectid: window.Application.currentProject.get("projectid"), isGloss: 0, source: key, limit: 100}})).done(function () {
                     lstTU = buildTUList(window.Application.kbList);
                     $("#lstTU").html(lstTU);
                     // nFilteredTotal from our getCount above

--- a/www/js/views/SearchViews.js
+++ b/www/js/views/SearchViews.js
@@ -186,6 +186,7 @@ define(function (require) {
                 this.render();
             },
             events: {
+                "input #search":    "search",
                 "click .big-link": "onClickTU",
                 "click #btnNewTU": "onClickNewTU"
             },
@@ -202,6 +203,42 @@ define(function (require) {
                 console.log("onClickNewTU - entry");
                 window.Application.router.navigate("tu", {trigger: true});
             },
+
+            search: function (event) {
+                var lstTU = "";
+                var rs = null;
+                if (event.keycode === 13) { // enter key pressed
+                    event.preventDefault();
+                }
+                this.TUList = window.Application.kbList;
+                var key = $('#search').val();
+                if (key.length > 0) {
+                    // filter based on search text
+                    this.TUList.fetch({data: {source: key}});
+                }
+                this.TUList.comparator = 'source';
+                this.TUList.sort();
+                lstTU += "<li class=\"topcoat-list__item li-tu\"><div class=\"big-link\" id=\"btnNewTU\"><div class=\"chap-list__item emphasized refstring-list__item filter-burnt-orange\"><span class=\"img-plus-small\" style=\"padding-right: 16px;\"></span>" + i18next.t("view.lblNewTU") + "</div></div></li>";
+                this.TUList.each(function (model, index) {
+                    // TODO: what to do with placeholder text? Currently filtered out here
+                    if (model.get("source").length > 0) {
+                        lstTU += "<li class=\"topcoat-list__item li-tu\"><a class=\"big-link\" id=\"" + model.get("tuid") + "\"><span class=\"chap-list__item emphasized\">" + model.get("source") + "</span><br><span class=\"sectionStatus\">";
+                        rs = model.get("refstring");
+                        if (rs.length > 1) {
+                            // multiple translations - give a count
+                            lstTU += i18next.t("view.ttlTotalTranslations", {total: rs.length});
+                        } else if (rs.length === 1) {
+                            // exactly 1 translation - just display it
+                            lstTU += rs[0].target;
+                        } else {
+                            // no translations (shouldn't happen)
+                            lstTU += i18next.t("view.ttlNoTranslations");
+                        }
+                        lstTU += "</span><span class=\"chevron\"></span></a></li>";
+                    }
+                });
+                $("#lstTU").html(lstTU);
+            },            
             onShow: function () {
                 var lstTU = "";
                 var rs = null;

--- a/www/js/views/SearchViews.js
+++ b/www/js/views/SearchViews.js
@@ -391,8 +391,9 @@ define(function (require) {
             // User clicked the OK button (new TU). Save the TU and add it to our TUList
             onOK: function () {
                 this.model.save();
-                window.Application.kblist.add(this.model);
+                window.Application.kbList.add(this.model);
                 window.history.go(-1);
+                // window.Application.editKB(window.Application.currentProject.get("projectid"));
             },
             // User clicked the Cancel button (new TU). Delete the TU and return to the TU List page.
             onCancel: function () {
@@ -446,11 +447,16 @@ define(function (require) {
             },
             // user clicked on the "new translation" button - prompt the user for a new translation string,
             // and then update the refstrings list if the user clicks OK
-            onNewRS: function () {
+            onNewRS: function (event) {
+                // prevent event from bubbling up
+                event.stopPropagation();
+                event.preventDefault();
+                // if there's no source, get out
                 if ($("#btnNewRS").hasClass("filter-gray")) {
                     return; // button is disabled - exit
                 }
                 console.log("onNewRS - entry");
+                // ask the user to provide a target / translation for the source phrase
                 if (navigator.notification) {
                     // on mobile device
                     var obj = this.model;

--- a/www/js/views/SearchViews.js
+++ b/www/js/views/SearchViews.js
@@ -168,9 +168,7 @@ define(function (require) {
         TUListView = Marionette.ItemView.extend({
             template: Handlebars.compile(tplTUList),
             initialize: function () {
-                this.TUList = new tuModels.TargetUnitCollection();
                 this.render();
-
             },
             events: {
                 "click .big-link": "onClickTU",
@@ -195,7 +193,9 @@ define(function (require) {
                 var strInfo = "";
                 // first item in list -- create a new TU
                 // lstTU += "<li class=\"topcoat-list__item\"><a class=\"big-link\" id=\"btnNewTU\"><span class=\"btn-plus\"></span>" + i18next.t("view.lblProjectSettings") + "<span class=\"chevron\"></span></a></li>";
-                this.TUList.fetch({reset: true, data: {projectid: this.model.get('projectid')}});
+                this.TUList = window.Application.kbList;
+                // this.TUList.fetch({reset: true, data: {projectid: this.model.get('projectid')}});
+                console.log("onShow: this.TUList.length = " + this.TUList.length);
                 // initial sort - name
                 this.TUList.comparator = 'source';
                 this.TUList.sort();
@@ -252,7 +252,7 @@ define(function (require) {
                     timestamp = (curDate.getFullYear() + "-" + (curDate.getMonth() + 1) + "-" + curDate.getDay() + "T" + curDate.getUTCHours() + ":" + curDate.getUTCMinutes() + ":" + curDate.getUTCSeconds() + "z");
                 txtSource = $("#txtSource").val().trim();
                 txtTarget = $("#txtTarget").val().trim();
-                var elts = kblist.filter(function (element) {
+                var elts = window.Application.kbList.filter(function (element) {
                     return (element.attributes.projectid === projectid &&
                        element.attributes.source === txtSource && element.attributes.isGloss === 0);
                 });
@@ -321,7 +321,7 @@ define(function (require) {
                     // create a new / temporary TU to pass in to the TUView
                     // (this object isn't saved or added to the collection yet)
                     var newID = window.Application.generateUUID(),
-                        theTU = new kbModels.TargetUnit({
+                        theTU = new tuModels.TargetUnit({
                             tuid: newID,
                             projectid: window.Application.currentProject.get("projectid"),
                             source: txtSource,

--- a/www/js/views/SearchViews.js
+++ b/www/js/views/SearchViews.js
@@ -559,8 +559,7 @@ define(function (require) {
                 var index = event.currentTarget.parentElement.parentElement.id.substr(4);
                 var refstrings = this.model.get("refstring");
                 var src = this.model.get("source");
-                var sp = this.spList.at(0);
-                var spLength = sp.get("source").length - (sp.get("prepuncts").length + sp.get("follpuncts").length);
+                var spLength = src.length;
                 var tgt = refstrings[index].target;
                 var i = 0;
                 var count = 0;
@@ -580,7 +579,7 @@ define(function (require) {
                         return true;
                     }
                     // do the strings differ in just punctuation?
-                    var tmpVal = element.attributes.target.toUpperCase().substring(0, element.attributes.target.length - element.attributes.follpuncts.length);
+                    var tmpVal = element.attributes.target.toUpperCase().substring(0, element.attributes.prepuncts.length + element.attributes.target.length - element.attributes.follpuncts.length);
                     tmpVal = tmpVal.substring(element.attributes.prepuncts.length);
                     if (tmpVal === tgt.toUpperCase()) {
                         return true; // string is the same, it just has punctuation tacked on

--- a/www/locales/dev/translation.json
+++ b/www/locales/dev/translation.json
@@ -371,6 +371,8 @@
         "dscErrSFMLexBadMarker": "Unknown marker: \"__mkr__\". Adapt It Mobile can only import key word / Standard Format Files with \\lx and \\ge markers.",
         "ttlTranslations": "Translations",
         "ttlProjectName": "Project: __name__",
+        "ttlTotalTranslations": "(__total__ translations)",
+        "ttlNoTranslations": "No translations",
         "ttlTotalEntries": "Total Entries: __total__",
         "_comment" : "****Add new strings BEFORE this line!****"
     },

--- a/www/locales/dev/translation.json
+++ b/www/locales/dev/translation.json
@@ -370,6 +370,8 @@
         "dscErrSFMLexNotFound": "Unable to find \\lx or \\ge data in this file.",
         "dscErrSFMLexBadMarker": "Unknown marker: \"__mkr__\". Adapt It Mobile can only import key word / Standard Format Files with \\lx and \\ge markers.",
         "ttlTranslations": "Translations",
+        "ttlProjectName": "Project: __name__",
+        "ttlTotalEntries": "Total Entries: __total__",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/dev/translation.json
+++ b/www/locales/dev/translation.json
@@ -376,7 +376,8 @@
         "ttlTotalEntries": "Total Entries: __total__",
         "lblNewTU": "Add Entry...",
         "lblNewRS": "Add Translation...",
-        "dscNewRS": "Enter a new translation for __source__:",
+        "dscNewSP": "Enter a new source phrase in language \"__lang__\": ",
+        "dscNewRS": "Enter a new translation for \"__source__\": ",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/dev/translation.json
+++ b/www/locales/dev/translation.json
@@ -374,6 +374,7 @@
         "ttlTotalTranslations": "(__total__ translations)",
         "ttlNoTranslations": "No translations",
         "ttlTotalEntries": "Total Entries: __total__",
+        "lblNewTU": "Add Entry...",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/dev/translation.json
+++ b/www/locales/dev/translation.json
@@ -376,7 +376,7 @@
         "ttlTotalEntries": "Total Entries: __total__",
         "lblNewTU": "Add Entry...",
         "lblNewRS": "Add Translation...",
-        "dscNewSP": "Enter a word or phrase in language \"__lang__\".",
+        "dscNewSP": "Enter a word or phrase in language \"__src__\", and a translation in language \"__tgt__\". You can add more translations by clicking on the \"Add Translation...\" button.",
         "dscNewRS": "Enter a translation for \"__source__\".",
         "_comment" : "****Add new strings BEFORE this line!****"
     },

--- a/www/locales/dev/translation.json
+++ b/www/locales/dev/translation.json
@@ -378,6 +378,8 @@
         "lblNewRS": "Add Translation...",
         "dscNewSP": "Enter a word or phrase in language \"__src__\", and a translation in language \"__tgt__\". You can add more translations by clicking on the \"Add Translation...\" button.",
         "dscNewRS": "Enter a translation for \"__source__\".",
+        "lblRange": "__pgStart__-__pgEnd__ of __total__",
+        "lblNoEntries": "No entries found.",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/dev/translation.json
+++ b/www/locales/dev/translation.json
@@ -375,6 +375,8 @@
         "ttlNoTranslations": "No translations",
         "ttlTotalEntries": "Total Entries: __total__",
         "lblNewTU": "Add Entry...",
+        "lblNewRS": "Add Translation...",
+        "dscNewRS": "Enter a new translation for __source__:",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/dev/translation.json
+++ b/www/locales/dev/translation.json
@@ -376,8 +376,8 @@
         "ttlTotalEntries": "Total Entries: __total__",
         "lblNewTU": "Add Entry...",
         "lblNewRS": "Add Translation...",
-        "dscNewSP": "Enter a new source phrase in language \"__lang__\": ",
-        "dscNewRS": "Enter a new translation for \"__source__\": ",
+        "dscNewSP": "Enter a word or phrase in language \"__lang__\".",
+        "dscNewRS": "Enter a translation for \"__source__\".",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/en/translation.json
+++ b/www/locales/en/translation.json
@@ -371,6 +371,8 @@
         "dscErrSFMLexBadMarker": "Unknown marker: \"__mkr__\". Adapt It Mobile can only import key word / Standard Format Files with \\lx and \\ge markers.",
         "ttlTranslations": "Translations",
         "ttlProjectName": "Project: __name__",
+        "ttlTotalTranslations": "(__total__ translations)",
+        "ttlNoTranslations": "No translations",
         "ttlTotalEntries": "Total Entries: __total__",
         "_comment" : "****Add new strings BEFORE this line!****"
     },

--- a/www/locales/en/translation.json
+++ b/www/locales/en/translation.json
@@ -370,6 +370,8 @@
         "dscErrSFMLexNotFound": "Unable to find \\lx or \\ge data in this file.",
         "dscErrSFMLexBadMarker": "Unknown marker: \"__mkr__\". Adapt It Mobile can only import key word / Standard Format Files with \\lx and \\ge markers.",
         "ttlTranslations": "Translations",
+        "ttlProjectName": "Project: __name__",
+        "ttlTotalEntries": "Total Entries: __total__",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/en/translation.json
+++ b/www/locales/en/translation.json
@@ -374,6 +374,7 @@
         "ttlTotalTranslations": "(__total__ translations)",
         "ttlNoTranslations": "No translations",
         "ttlTotalEntries": "Total Entries: __total__",
+        "lblNewTU": "Add Entry...",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/en/translation.json
+++ b/www/locales/en/translation.json
@@ -376,7 +376,8 @@
         "ttlTotalEntries": "Total Entries: __total__",
         "lblNewTU": "Add Entry...",
         "lblNewRS": "Add Translation...",
-        "dscNewRS": "Enter a new translation for __source__:",
+        "dscNewSP": "Enter a new source phrase in language \"__lang__\".",
+        "dscNewRS": "Enter a translation for \"__source__\" in language __lang__.",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/en/translation.json
+++ b/www/locales/en/translation.json
@@ -376,8 +376,8 @@
         "ttlTotalEntries": "Total Entries: __total__",
         "lblNewTU": "Add Entry...",
         "lblNewRS": "Add Translation...",
-        "dscNewSP": "Enter a new source phrase in language \"__lang__\".",
-        "dscNewRS": "Enter a translation for \"__source__\" in language __lang__.",
+        "dscNewSP": "Enter a word or phrase in language \"__lang__\".",
+        "dscNewRS": "Enter a translation for \"__source__\".",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/en/translation.json
+++ b/www/locales/en/translation.json
@@ -376,7 +376,7 @@
         "ttlTotalEntries": "Total Entries: __total__",
         "lblNewTU": "Add Entry...",
         "lblNewRS": "Add Translation...",
-        "dscNewSP": "Enter a word or phrase in language \"__lang__\".",
+        "dscNewSP": "Enter a word or phrase in language \"__src__\", and a translation in language \"__tgt__\". You can add more translations by clicking on the \"Add Translation...\" button.",
         "dscNewRS": "Enter a translation for \"__source__\".",
         "_comment" : "****Add new strings BEFORE this line!****"
     },

--- a/www/locales/en/translation.json
+++ b/www/locales/en/translation.json
@@ -378,6 +378,8 @@
         "lblNewRS": "Add Translation...",
         "dscNewSP": "Enter a word or phrase in language \"__src__\", and a translation in language \"__tgt__\". You can add more translations by clicking on the \"Add Translation...\" button.",
         "dscNewRS": "Enter a translation for \"__source__\".",
+        "lblRange": "__pgStart__-__pgEnd__ of __total__",
+        "lblNoEntries": "No entries found.",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/en/translation.json
+++ b/www/locales/en/translation.json
@@ -375,6 +375,8 @@
         "ttlNoTranslations": "No translations",
         "ttlTotalEntries": "Total Entries: __total__",
         "lblNewTU": "Add Entry...",
+        "lblNewRS": "Add Translation...",
+        "dscNewRS": "Enter a new translation for __source__:",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/es/translation.json
+++ b/www/locales/es/translation.json
@@ -376,7 +376,7 @@
         "ttlTotalEntries": "Recuento de elementos: __total__",
         "lblNewTU": "Nuevo elemento...",
         "lblNewRS": "Nueva Traducción...",
-        "dscNewSP": "Escriba una palabra o frase en el idioma \"__lang__\".",
+        "dscNewSP": "Escriba una palabra o frase en el idioma \"__src__\" y una traducción en el idioma \"__tgt__\". Puede agregar más traducciones haciendo clic en el botón \"Nueva traducción...\".",
         "dscNewRS": "Escriba una traducción para \"__source__\".",
         "_comment" : "****Add new strings BEFORE this line!****"
     },

--- a/www/locales/es/translation.json
+++ b/www/locales/es/translation.json
@@ -378,6 +378,8 @@
         "lblNewRS": "Nueva Traducción...",
         "dscNewSP": "Escriba una palabra o frase en el idioma \"__src__\" y una traducción en el idioma \"__tgt__\". Puede agregar más traducciones haciendo clic en el botón \"Nueva traducción...\".",
         "dscNewRS": "Escriba una traducción para \"__source__\".",
+        "lblRange": "__pgStart__-__pgEnd__ de __total__",
+        "lblNoEntries": "No se encontraron elementos.",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/es/translation.json
+++ b/www/locales/es/translation.json
@@ -374,6 +374,7 @@
         "ttlTotalTranslations": "(__total__ traducciones)",
         "ttlNoTranslations": "No hay traducciones",
         "ttlTotalEntries": "Recuento de elementos: __total__",
+        "lblNewTU": "Nuevo elemento...",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/es/translation.json
+++ b/www/locales/es/translation.json
@@ -376,7 +376,8 @@
         "ttlTotalEntries": "Recuento de elementos: __total__",
         "lblNewTU": "Nuevo elemento...",
         "lblNewRS": "Nueva Traducción...",
-        "dscNewRS": "Escriba una nueva traducción para __source__:",
+        "dscNewSP": "Escriba una palabra o frase en el idioma \"__lang__\": ",
+        "dscNewRS": "Escriba una nueva traducción para \"__source__\": ",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/es/translation.json
+++ b/www/locales/es/translation.json
@@ -370,6 +370,8 @@
         "dscErrSFMLexNotFound": "No se puede encontrar los marcadores \\lx o \\ge en este archivo.",
         "dscErrSFMLexBadMarker": "Marcador desconocido: \"__mkr__\". Adapt It Mobile solo puede actualizar la Base de conocimiento desde archivos SFM con marcadores \\lx y \\ge.",
         "ttlTranslations": "Traducciones",
+        "ttlProjectName": "Proyecto: __name__",
+        "ttlTotalEntries": "Recuento de elementos: __total__",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/es/translation.json
+++ b/www/locales/es/translation.json
@@ -376,8 +376,8 @@
         "ttlTotalEntries": "Recuento de elementos: __total__",
         "lblNewTU": "Nuevo elemento...",
         "lblNewRS": "Nueva Traducción...",
-        "dscNewSP": "Escriba una palabra o frase en el idioma \"__lang__\": ",
-        "dscNewRS": "Escriba una nueva traducción para \"__source__\": ",
+        "dscNewSP": "Escriba una palabra o frase en el idioma \"__lang__\".",
+        "dscNewRS": "Escriba una traducción para \"__source__\".",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/es/translation.json
+++ b/www/locales/es/translation.json
@@ -371,6 +371,8 @@
         "dscErrSFMLexBadMarker": "Marcador desconocido: \"__mkr__\". Adapt It Mobile solo puede actualizar la Base de conocimiento desde archivos SFM con marcadores \\lx y \\ge.",
         "ttlTranslations": "Traducciones",
         "ttlProjectName": "Proyecto: __name__",
+        "ttlTotalTranslations": "(__total__ traducciones)",
+        "ttlNoTranslations": "No hay traducciones",
         "ttlTotalEntries": "Recuento de elementos: __total__",
         "_comment" : "****Add new strings BEFORE this line!****"
     },

--- a/www/locales/es/translation.json
+++ b/www/locales/es/translation.json
@@ -375,6 +375,8 @@
         "ttlNoTranslations": "No hay traducciones",
         "ttlTotalEntries": "Recuento de elementos: __total__",
         "lblNewTU": "Nuevo elemento...",
+        "lblNewRS": "Nueva Traducción...",
+        "dscNewRS": "Escriba una nueva traducción para __source__:",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/fr/translation.json
+++ b/www/locales/fr/translation.json
@@ -376,7 +376,7 @@
         "ttlTotalEntries": "Nombre d'entrées: __total__",
         "lblNewTU": "Nouvelle entrée...",
         "lblNewRS": "Nouvelle traduction...",
-        "dscNewSP": "Entrez un mot ou une phrase dans la langue \"__lang__\".",
+        "dscNewSP": "Entrez un mot ou une expression dans la langue \"__src__\" et une traduction dans la langue \"__tgt__\". Vous pouvez ajouter plus de traductions en cliquant sur le bouton \"Nouvelle traduction...\".",
         "dscNewRS": "Entrez une traduction pour \"__source__\".",
         "_comment" : "****Add new strings BEFORE this line!****"
     },

--- a/www/locales/fr/translation.json
+++ b/www/locales/fr/translation.json
@@ -374,6 +374,7 @@
         "ttlTotalTranslations": "(__total__ traductions)",
         "ttlNoTranslations": "Il n'y a pas de traductions",
         "ttlTotalEntries": "Nombre d'éléments: __total__",
+        "lblNewTU": "Nouvel élément...",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/fr/translation.json
+++ b/www/locales/fr/translation.json
@@ -371,6 +371,8 @@
         "dscErrSFMLexBadMarker": "Marqueur inconnu: \"__mkr__\". Adapt It Mobile ne peut mettre à jour la base de connaissances qu'à partir de fichiers SFM avec des marqueurs \\lx et \\ge.",
         "ttlTranslations": "Traductions",
         "ttlProjectName": "Projet: __name__",
+        "ttlTotalTranslations": "(__total__ traductions)",
+        "ttlNoTranslations": "Il n'y a pas de traductions",
         "ttlTotalEntries": "Nombre d'éléments: __total__",
         "_comment" : "****Add new strings BEFORE this line!****"
     },

--- a/www/locales/fr/translation.json
+++ b/www/locales/fr/translation.json
@@ -376,7 +376,8 @@
         "ttlTotalEntries": "Nombre d'entrées: __total__",
         "lblNewTU": "Nouvelle entrée...",
         "lblNewRS": "Nouvelle traduction...",
-        "dscNewRS": "Entrez une nouvelle traduction pour __source__:",
+        "dscNewSP": "Entrez un mot ou une phrase dans la langue \"__lang__\": ",
+        "dscNewRS": "Entrez une nouvelle traduction pour \"__source__\": ",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/fr/translation.json
+++ b/www/locales/fr/translation.json
@@ -378,6 +378,8 @@
         "lblNewRS": "Nouvelle traduction...",
         "dscNewSP": "Entrez un mot ou une expression dans la langue \"__src__\" et une traduction dans la langue \"__tgt__\". Vous pouvez ajouter plus de traductions en cliquant sur le bouton \"Nouvelle traduction...\".",
         "dscNewRS": "Entrez une traduction pour \"__source__\".",
+        "lblRange": "__pgStart__-__pgEnd__ sur __total__",
+        "lblNoEntries": "Aucune entrée trouvée.",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/fr/translation.json
+++ b/www/locales/fr/translation.json
@@ -373,8 +373,10 @@
         "ttlProjectName": "Projet: __name__",
         "ttlTotalTranslations": "(__total__ traductions)",
         "ttlNoTranslations": "Il n'y a pas de traductions",
-        "ttlTotalEntries": "Nombre d'éléments: __total__",
-        "lblNewTU": "Nouvel élément...",
+        "ttlTotalEntries": "Nombre d'entrées: __total__",
+        "lblNewTU": "Nouvelle entrée...",
+        "lblNewRS": "Nouvelle traduction...",
+        "dscNewRS": "Entrez une nouvelle traduction pour __source__:",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/fr/translation.json
+++ b/www/locales/fr/translation.json
@@ -376,8 +376,8 @@
         "ttlTotalEntries": "Nombre d'entrées: __total__",
         "lblNewTU": "Nouvelle entrée...",
         "lblNewRS": "Nouvelle traduction...",
-        "dscNewSP": "Entrez un mot ou une phrase dans la langue \"__lang__\": ",
-        "dscNewRS": "Entrez une nouvelle traduction pour \"__source__\": ",
+        "dscNewSP": "Entrez un mot ou une phrase dans la langue \"__lang__\".",
+        "dscNewRS": "Entrez une traduction pour \"__source__\".",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/fr/translation.json
+++ b/www/locales/fr/translation.json
@@ -370,6 +370,8 @@
         "dscErrSFMLexNotFound": "Impossible de trouver les marqueurs \\lx ou \\ge dans ce fichier.",
         "dscErrSFMLexBadMarker": "Marqueur inconnu: \"__mkr__\". Adapt It Mobile ne peut mettre à jour la base de connaissances qu'à partir de fichiers SFM avec des marqueurs \\lx et \\ge.",
         "ttlTranslations": "Traductions",
+        "ttlProjectName": "Projet: __name__",
+        "ttlTotalEntries": "Nombre d'éléments: __total__",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/pt/translation.json
+++ b/www/locales/pt/translation.json
@@ -374,6 +374,7 @@
         "ttlTotalTranslations": "(__total__ traduções)",
         "ttlNoTranslations": "Não há traduções",
         "ttlTotalEntries": "Contagem de itens: __total__",
+        "lblNewTU": "Nova iten...",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/pt/translation.json
+++ b/www/locales/pt/translation.json
@@ -371,6 +371,8 @@
         "dscErrSFMLexBadMarker": "Marcador desconhecido: \"__mkr__\". Adapt It Mobile só pode atualizar a Base de Conhecimento de arquivos SFM com marcadores \\lx e \\ge.",
         "ttlTranslations": "Traduções",
         "ttlProjectName": "Projecto: __name__",
+        "ttlTotalTranslations": "(__total__ traduções)",
+        "ttlNoTranslations": "Não há traduções",
         "ttlTotalEntries": "Contagem de itens: __total__",
         "_comment" : "****Add new strings BEFORE this line!****"
     },

--- a/www/locales/pt/translation.json
+++ b/www/locales/pt/translation.json
@@ -378,6 +378,8 @@
         "lblNewRS": "Nova tradução...",
         "dscNewSP": "Digite uma palavra ou frase no idioma \"__src__\" e uma tradução no idioma \"__tgt__\". Você pode adicionar mais traduções clicando no botão \"Nova Tradução...\".",
         "dscNewRS": "Digite uma tradução para \"__source__\".",
+        "lblRange": "__pgStart__-__pgEnd__ de __total__",
+        "lblNoEntries": "Nenhuma iten encontrada.",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/pt/translation.json
+++ b/www/locales/pt/translation.json
@@ -370,6 +370,8 @@
         "dscErrSFMLexNotFound": "Não foi possível localizar os marcadores \\lx ou \\ge neste arquivo.",
         "dscErrSFMLexBadMarker": "Marcador desconhecido: \"__mkr__\". Adapt It Mobile só pode atualizar a Base de Conhecimento de arquivos SFM com marcadores \\lx e \\ge.",
         "ttlTranslations": "Traduções",
+        "ttlProjectName": "Projecto: __name__",
+        "ttlTotalEntries": "Contagem de itens: __total__",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/pt/translation.json
+++ b/www/locales/pt/translation.json
@@ -376,7 +376,8 @@
         "ttlTotalEntries": "Contagem de itens: __total__",
         "lblNewTU": "Nova iten...",
         "lblNewRS": "Nova tradução...",
-        "dscNewRS": "Digite uma nova tradução para __source__:",
+        "dscNewSP": "Digite uma palavra ou frase no idioma \"__lang__\": ",
+        "dscNewRS": "Digite uma nova tradução para \"__source__\": ",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/pt/translation.json
+++ b/www/locales/pt/translation.json
@@ -375,6 +375,8 @@
         "ttlNoTranslations": "Não há traduções",
         "ttlTotalEntries": "Contagem de itens: __total__",
         "lblNewTU": "Nova iten...",
+        "lblNewRS": "Nova tradução...",
+        "dscNewRS": "Digite uma nova tradução para __source__:",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/pt/translation.json
+++ b/www/locales/pt/translation.json
@@ -376,8 +376,8 @@
         "ttlTotalEntries": "Contagem de itens: __total__",
         "lblNewTU": "Nova iten...",
         "lblNewRS": "Nova tradução...",
-        "dscNewSP": "Digite uma palavra ou frase no idioma \"__lang__\": ",
-        "dscNewRS": "Digite uma nova tradução para \"__source__\": ",
+        "dscNewSP": "Digite uma palavra ou frase no idioma \"__lang__\".",
+        "dscNewRS": "Digite uma tradução para \"__source__\".",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/pt/translation.json
+++ b/www/locales/pt/translation.json
@@ -376,7 +376,7 @@
         "ttlTotalEntries": "Contagem de itens: __total__",
         "lblNewTU": "Nova iten...",
         "lblNewRS": "Nova tradução...",
-        "dscNewSP": "Digite uma palavra ou frase no idioma \"__lang__\".",
+        "dscNewSP": "Digite uma palavra ou frase no idioma \"__src__\" e uma tradução no idioma \"__tgt__\". Você pode adicionar mais traduções clicando no botão \"Nova Tradução...\".",
         "dscNewRS": "Digite uma tradução para \"__source__\".",
         "_comment" : "****Add new strings BEFORE this line!****"
     },

--- a/www/locales/tpi/translation.json
+++ b/www/locales/tpi/translation.json
@@ -371,6 +371,8 @@
         "dscErrSFMLexBadMarker": "Unknown marker: \"__mkr__\". Adapt It Mobile can only import key word / Standard Format Files with \\lx and \\ge markers.",
         "ttlTranslations": "Trenslesens",
         "ttlProjectName": "Projek: __name__",
+        "ttlTotalTranslations": "(__total__ trenslesen)",
+        "ttlNoTranslations": "Nogat trenslesen",
         "ttlTotalEntries": "Olgeta: __total__",
         "_comment" : "****Add new strings BEFORE this line!****"
     },

--- a/www/locales/tpi/translation.json
+++ b/www/locales/tpi/translation.json
@@ -376,7 +376,8 @@
         "ttlTotalEntries": "Olgeta: __total__",
         "lblNewTU": "Nupela trenslesen...",
         "lblNewRS": "Nupela trenslesen...",
-        "dscNewRS": "Enter a new translation for __source__:",
+        "dscNewSP": "Enter a new source phrase in language \"__lang__\": ",
+        "dscNewRS": "Enter a new translation for \"__source__\": ",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/tpi/translation.json
+++ b/www/locales/tpi/translation.json
@@ -376,8 +376,8 @@
         "ttlTotalEntries": "Olgeta: __total__",
         "lblNewTU": "Nupela trenslesen...",
         "lblNewRS": "Nupela trenslesen...",
-        "dscNewSP": "Enter a new source phrase in language \"__lang__\": ",
-        "dscNewRS": "Enter a new translation for \"__source__\": ",
+        "dscNewSP": "Enter a word or phrase in language \"__lang__\".",
+        "dscNewRS": "Enter a translation for \"__source__\".",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/tpi/translation.json
+++ b/www/locales/tpi/translation.json
@@ -370,6 +370,8 @@
         "dscErrSFMLexNotFound": "Unable to find \\lx or \\ge data in this file.",
         "dscErrSFMLexBadMarker": "Unknown marker: \"__mkr__\". Adapt It Mobile can only import key word / Standard Format Files with \\lx and \\ge markers.",
         "ttlTranslations": "Trenslesens",
+        "ttlProjectName": "Projek: __name__",
+        "ttlTotalEntries": "Olgeta: __total__",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/tpi/translation.json
+++ b/www/locales/tpi/translation.json
@@ -375,6 +375,8 @@
         "ttlNoTranslations": "Nogat trenslesen",
         "ttlTotalEntries": "Olgeta: __total__",
         "lblNewTU": "Nupela trenslesen...",
+        "lblNewRS": "Nupela trenslesen...",
+        "dscNewRS": "Enter a new translation for __source__:",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/tpi/translation.json
+++ b/www/locales/tpi/translation.json
@@ -378,6 +378,8 @@
         "lblNewRS": "Nupela trenslesen...",
         "dscNewSP": "Enter a word or phrase in language \"__lang__\".",
         "dscNewRS": "Enter a translation for \"__source__\".",
+        "lblRange": "__pgStart__-__pgEnd__ of __total__",
+        "lblNoEntries": "No entries found.",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/locales/tpi/translation.json
+++ b/www/locales/tpi/translation.json
@@ -369,11 +369,12 @@
         "dscRestoreOrMergeSFMLex": "This is a Standard Format file containing data for the Knowledge Base (\\lx and \\ge). You can Restore the Knowledge Base from the imported file, or Merge the file with existing translations.",
         "dscErrSFMLexNotFound": "Unable to find \\lx or \\ge data in this file.",
         "dscErrSFMLexBadMarker": "Unknown marker: \"__mkr__\". Adapt It Mobile can only import key word / Standard Format Files with \\lx and \\ge markers.",
-        "ttlTranslations": "Trenslesens",
+        "ttlTranslations": "Trenslesen",
         "ttlProjectName": "Projek: __name__",
         "ttlTotalTranslations": "(__total__ trenslesen)",
         "ttlNoTranslations": "Nogat trenslesen",
         "ttlTotalEntries": "Olgeta: __total__",
+        "lblNewTU": "Nupela trenslesen...",
         "_comment" : "****Add new strings BEFORE this line!****"
     },
     "help": {

--- a/www/res/css/styles.css
+++ b/www/res/css/styles.css
@@ -373,7 +373,7 @@ header h3 {
 }
 .search-bar {
     display: none;
-    background-color: rgb(215,220,220);
+    background-color: rgb(214,218,220);
     border-top: 1px solid #1f7ba5;
     flex-direction: row;
     justify-content: flex-end;
@@ -386,6 +386,15 @@ header h3 {
 }
 .search-label {
     padding: 6px;
+}
+.relative-search-bar {
+    background-color: rgb(207,214,218);
+    flex-direction: row;
+    justify-content: flex-end;
+    display: flex;
+    height: 32px;
+    width: 100%;
+    padding: 0px 1px;
 }
 #SearchRS {
     flex-grow: 1;

--- a/www/res/css/styles.css
+++ b/www/res/css/styles.css
@@ -1419,6 +1419,11 @@ div.specialtext div.source {
     overflow: hidden;
 }
 
+.li-tu {
+    /* less padding on top/bottom */
+    padding: .5rem 1rem .5rem 1rem;
+}
+
 #StepContainer {
     position: static;
 }

--- a/www/res/css/styles.css
+++ b/www/res/css/styles.css
@@ -42,8 +42,11 @@
     background-color: #b26200;
     color: white;
 }
-.filter-burnt-orange { /* use CSS filter to turn black SVG images burnt orange */
+.filter-burnt-orange { /* CSS filter to display black as burnt orange */
     filter: invert(28%) sepia(67%) saturate(2780%) hue-rotate(33deg) brightness(101%) contrast(101%);
+}
+.filter-gray { /* CSS filter to display black as gray / disabled */
+    filter: invert(62%) sepia(0%) saturate(268%) hue-rotate(139deg) brightness(98%) contrast(91%);
 }
 .bg-darkdarkblue {
     background-color: #12536d;

--- a/www/res/css/styles.css
+++ b/www/res/css/styles.css
@@ -42,6 +42,9 @@
     background-color: #b26200;
     color: white;
 }
+.filter-burnt-orange { /* use CSS filter to turn black SVG images burnt orange */
+    filter: invert(28%) sepia(67%) saturate(2780%) hue-rotate(33deg) brightness(101%) contrast(101%);
+}
 .bg-darkdarkblue {
     background-color: #12536d;
     color: white;

--- a/www/tpl/EditProject.html
+++ b/www/tpl/EditProject.html
@@ -33,13 +33,11 @@
     <header><h3>{{t 'view.ttlManageProjects'}}</h3></header>
     <span class="chevron"></span></a>
 </li>
-<!--
 <li class="topcoat-list__item">
     <a id="KBEditor">
     <header><h3>{{t 'view.lblKB'}}</h3></header>
     <span class="chevron"></span></a>
 </li>
--->
 </ul>
 <div class="topcoat-list__header" id="lblAllTrans">{{t 'view.ttlCurrentProjectSettings'}}</div>
 <ul class="chapter-list topcoat-list__container">

--- a/www/tpl/NewTU.html
+++ b/www/tpl/NewTU.html
@@ -12,18 +12,21 @@
         <h2>{{t 'view.lblNewTU'}}</h2>
     </div>
 </div>
-<div id="mobileSelect" class="scroller-notb">
+<div id="mobileSelect" class="scroller-bottom-tb">
     <div class="chapter-list topcoat-list__container" id="Container" style="width:100%">
+        <div class="wizard-instructions" id="StepInstructions"></div>
         <div class="control-group">
-            <div class="control-row" id="lblPrompt"></div>
-            <div class="control-row"><input type="text" id="txtField" class="topcoat-text-input full" value="" required></div>
+            <div class="control-row"><label id="lblSource" for="txtSource"></label><input type="text" id="txtSource" class="topcoat-text-input full" value="" required></div>
+            <div class="control-row"><label id="lblTarget" for="txtTarget"></label><input type="text" id="txtTarget" class="topcoat-text-input full" value="" required></div>
         </div>
-    </div>
+        <ul class="topcoat-list__container chapter-list"><li class="topcoat-list__item li-tu"><div class="big-link filter-burnt-orange" id="btnNewRS"><div class="chap-list__item emphasized refstring-list__item"><span class="img-plus-small" style="padding-right: 16px;"></span>{{t 'view.lblNewRS'}}</div></div></li></ul>
+        <div class="topcoat-list__header hide" id="lblAllTrans">{{t 'view.lblAllTranslations'}} <span class="right">{{t 'view.lblFrequency'}}</span></div>
+            <ul class="topcoat-list__container chapter-list" id="RefStrings"></ul>
+        </div>
 </div>    
 <div class="bottom-tb">
 <div id="WizardSteps">
     <button class="topcoat-button" id="Cancel"><span id="lblCancel">{{t 'view.lblCancel'}}</span></button>
-    <button class="topcoat-button" id="Next"><span id="lblNext"></span> <span class="topcoat-icon topcoat-icon--forward" id="imgNext"></span></button>
     <button class="topcoat-button" id="Done"><span id="lblDone">{{t 'view.lblDone'}}</span></button>
 </div>
 </div>

--- a/www/tpl/NewTU.html
+++ b/www/tpl/NewTU.html
@@ -15,8 +15,8 @@
 <div id="mobileSelect" class="scroller-notb">
     <div class="chapter-list topcoat-list__container" id="Container" style="width:100%">
         <div class="control-group">
-            <div class="control-row" id="lblText"></div>
-            <div class="control-row"><input type="text" id="txtField" class="topcoat-text-input full" required></div>
+            <div class="control-row" id="lblPrompt"></div>
+            <div class="control-row"><input type="text" id="txtField" class="topcoat-text-input full" value="" required></div>
         </div>
     </div>
 </div>    

--- a/www/tpl/NewTU.html
+++ b/www/tpl/NewTU.html
@@ -1,0 +1,29 @@
+{{! NewTU.html
+    Template for creating a new TargetUnit. Used by SearchViews.js (TuListView / New Entry).
+}}
+
+<div class="topcoat-navigation-bar main_title bg-lightblue">
+    <div class="topcoat-navigation-bar__item">
+        <a class="topcoat-icon-button--quiet back-button" id="btnBack">
+            <span class="topcoat-icon topcoat-icon--back"></span>
+        </a>
+    </div>
+    <div class="topcoat-navigation-bar__item half">
+        <h2>{{t 'view.lblNewTU'}}</h2>
+    </div>
+</div>
+<div id="mobileSelect" class="scroller-notb">
+    <div class="chapter-list topcoat-list__container" id="Container" style="width:100%">
+        <div class="control-group">
+            <div class="control-row" id="lblText"></div>
+            <div class="control-row"><input type="text" id="txtField" class="topcoat-text-input full" required></div>
+        </div>
+    </div>
+</div>    
+<div class="bottom-tb">
+<div id="WizardSteps">
+    <button class="topcoat-button" id="Cancel"><span id="lblCancel">{{t 'view.lblCancel'}}</span></button>
+    <button class="topcoat-button" id="Next"><span id="lblNext"></span> <span class="topcoat-icon topcoat-icon--forward" id="imgNext"></span></button>
+    <button class="topcoat-button" id="Done"><span id="lblDone">{{t 'view.lblDone'}}</span></button>
+</div>
+</div>

--- a/www/tpl/TargetUnit.html
+++ b/www/tpl/TargetUnit.html
@@ -1,7 +1,8 @@
 {{! TargetUnit.html
     Template for displaying an individual KB target unit (one or more translations for a single source phrase).
-    This template does double duty:
+    This template gets called from a few places:
     - Individual item view for the KB editor (accessed through the settings)
+    - Creating a new TU (same caller - KB editor)
     - "Show translations" screen (accessed when adapting)
     TUView in SearchViews.js creates this template.
 }}
@@ -20,4 +21,10 @@
         <div class="topcoat-list__header" id="lblAllTrans">{{t 'view.lblAllTranslations'}} <span class="right">{{t 'view.lblFrequency'}}</span></div>
         <ul class="topcoat-list__container chapter-list" id="RefStrings"></ul>
     </div>
-</div>    
+</div>
+<div class="bottom-tb hide" id="tbBottom">
+    <div id="OKCancelButtons">
+            <button class="topcoat-button" id="Cancel"><span id="lblCancel">{{t 'view.lblCancel'}}</span></button>
+            <button class="topcoat-button" id="OK"><span id="lblOK">{{t 'view.lblOK'}}</span></button>
+    </div>
+</div>

--- a/www/tpl/TargetUnit.html
+++ b/www/tpl/TargetUnit.html
@@ -9,8 +9,11 @@
 </div>
 <div id="mobileSelect" class="scroller-notb">
     <div class="chapter-list topcoat-list__container" id="Container" style="width:100%">
-        <div class="topcoat-list__header" id="lblCurrentTrans">{{t 'view.lblCurrentTranslation'}}</div>
-        <div class="srcbox"><div class="emphasized-small" id="lblSourceLang"></div><div class="center emphasized" id="srcPhrase">{{source}}</div></div><div class="tgtbox"><div><div class="emphasized-small" id="lbltargetLang"></div><div class="emphasized center"><span id="tgtPhrase" contenteditable="true"></span></div></div></div>
+        <div id="curSP">
+            <div class="topcoat-list__header" id="lblCurrentTrans">{{t 'view.lblCurrentTranslation'}}</div>
+            <div class="srcbox"><div class="emphasized-small" id="lblSourceLang"></div><div class="center emphasized" id="srcPhrase">{{source}}</div></div><div class="tgtbox"><div><div class="emphasized-small" id="lbltargetLang"></div><div class="emphasized center"><span id="tgtPhrase" contenteditable="true"></span></div></div></div>
+        </div>
+        <div id="noCurSP"></div>
         <div class="topcoat-list__header" id="lblAllTrans">{{t 'view.lblAllTranslations'}} <span class="right">{{t 'view.lblFrequency'}}</span></div>
         <ul class="topcoat-list__container chapter-list" id="RefStrings"></ul>
     </div>

--- a/www/tpl/TargetUnit.html
+++ b/www/tpl/TargetUnit.html
@@ -1,5 +1,9 @@
 {{! TargetUnit.html
     Template for displaying an individual KB target unit (one or more translations for a single source phrase).
+    This template does double duty:
+    - Individual item view for the KB editor (accessed through the settings)
+    - "Show translations" screen (accessed when adapting)
+    TUView in SearchViews.js creates this template.
 }}
 <div class="topcoat-navigation-bar main_title bg-lightblue">
     <div class="topcoat-navigation-bar__item">
@@ -9,11 +13,9 @@
 </div>
 <div id="mobileSelect" class="scroller-notb">
     <div class="chapter-list topcoat-list__container" id="Container" style="width:100%">
-        <div id="curSP">
-            <div class="topcoat-list__header" id="lblCurrentTrans">{{t 'view.lblCurrentTranslation'}}</div>
-            <div class="srcbox"><div class="emphasized-small" id="lblSourceLang"></div><div class="center emphasized" id="srcPhrase">{{source}}</div></div><div class="tgtbox"><div><div class="emphasized-small" id="lbltargetLang"></div><div class="emphasized center"><span id="tgtPhrase" contenteditable="true"></span></div></div></div>
-        </div>
-        <div id="noCurSP"></div>
+        <div class="topcoat-list__header" id="lblCurrentTrans">{{t 'view.lblCurrentTranslation'}}</div>
+        <div class="srcbox"><div class="emphasized-small" id="lblSourceLang"></div><div class="emphasized center"><span id="srcPhrase"></span></div></div>
+        <div class="tgtbox"><div class="emphasized-small" id="lbltargetLang"></div><div class="emphasized center"><span id="tgtPhrase" contenteditable="true"></span></div></div>
         <div class="topcoat-list__header" id="lblAllTrans">{{t 'view.lblAllTranslations'}} <span class="right">{{t 'view.lblFrequency'}}</span></div>
         <ul class="topcoat-list__container chapter-list" id="RefStrings"></ul>
     </div>

--- a/www/tpl/TargetUnit.html
+++ b/www/tpl/TargetUnit.html
@@ -16,6 +16,7 @@
         <div class="topcoat-list__header" id="lblCurrentTrans">{{t 'view.lblCurrentTranslation'}}</div>
         <div class="srcbox"><div class="emphasized-small" id="lblSourceLang"></div><div class="emphasized center"><span id="srcPhrase"></span></div></div>
         <div class="tgtbox"><div class="emphasized-small" id="lbltargetLang"></div><div class="emphasized center"><span id="tgtPhrase" contenteditable="true"></span></div></div>
+        <div class="control-row"><button class="topcoat-button" id="btnNewRS"><span class="img-plus-small"></span> {{t 'view.lblNewRS'}}</button></div>
         <div class="topcoat-list__header" id="lblAllTrans">{{t 'view.lblAllTranslations'}} <span class="right">{{t 'view.lblFrequency'}}</span></div>
         <ul class="topcoat-list__container chapter-list" id="RefStrings"></ul>
     </div>

--- a/www/tpl/TargetUnit.html
+++ b/www/tpl/TargetUnit.html
@@ -15,9 +15,9 @@
 <div id="mobileSelect" class="scroller-notb">
     <div class="chapter-list topcoat-list__container" id="Container" style="width:100%">
         <div class="topcoat-list__header" id="lblCurrentTrans">{{t 'view.lblCurrentTranslation'}}</div>
-        <div class="srcbox"><div class="emphasized-small" id="lblSourceLang"></div><div class="emphasized center"><span id="srcPhrase"></span></div></div>
-        <div class="tgtbox"><div class="emphasized-small" id="lbltargetLang"></div><div class="emphasized center"><span id="tgtPhrase" contenteditable="true"></span></div></div>
-        <ul class="topcoat-list__container chapter-list"><li class="topcoat-list__item li-tu"><div class="big-link" id="btnNewRS"><div class="chap-list__item emphasized refstring-list__item filter-burnt-orange"><span class="img-plus-small" style="padding-right: 16px;"></span>{{t 'view.lblNewRS'}}</div></div></li></ul>
+        <div class="srcbox" id="srcBox"><div class="emphasized-small" id="lblSourceLang"></div><div class="emphasized center"><span id="srcPhrase"></span></div></div>
+        <div class="tgtbox"><div class="emphasized-small" id="lbltargetLang"></div><div class="emphasized center"><span id="tgtPhrase"></span></div></div>
+        <ul class="topcoat-list__container chapter-list"><li class="topcoat-list__item li-tu"><div class="big-link filter-burnt-orange" id="btnNewRS"><div class="chap-list__item emphasized refstring-list__item"><span class="img-plus-small" style="padding-right: 16px;"></span>{{t 'view.lblNewRS'}}</div></div></li></ul>
         <div class="topcoat-list__header" id="lblAllTrans">{{t 'view.lblAllTranslations'}} <span class="right">{{t 'view.lblFrequency'}}</span></div>
         <ul class="topcoat-list__container chapter-list" id="RefStrings"></ul>
     </div>

--- a/www/tpl/TargetUnit.html
+++ b/www/tpl/TargetUnit.html
@@ -1,8 +1,7 @@
 {{! TargetUnit.html
     Template for displaying an individual KB target unit (one or more translations for a single source phrase).
-    This template gets called from a few places:
+    This template gets called from:
     - Individual item view for the KB editor (accessed through the settings)
-    - Creating a new TU (same caller - KB editor)
     - "Show translations" screen (accessed when adapting)
     TUView in SearchViews.js creates this template.
 }}
@@ -20,11 +19,5 @@
         <ul class="topcoat-list__container chapter-list"><li class="topcoat-list__item li-tu"><div class="big-link filter-burnt-orange" id="btnNewRS"><div class="chap-list__item emphasized refstring-list__item"><span class="img-plus-small" style="padding-right: 16px;"></span>{{t 'view.lblNewRS'}}</div></div></li></ul>
         <div class="topcoat-list__header" id="lblAllTrans">{{t 'view.lblAllTranslations'}} <span class="right">{{t 'view.lblFrequency'}}</span></div>
         <ul class="topcoat-list__container chapter-list" id="RefStrings"></ul>
-    </div>
-</div>
-<div class="bottom-tb hide" id="tbBottom">
-    <div id="OKCancelButtons">
-            <button class="topcoat-button" id="Cancel"><span id="lblCancel">{{t 'view.lblCancel'}}</span></button>
-            <button class="topcoat-button" id="OK"><span id="lblOK">{{t 'view.lblOK'}}</span></button>
     </div>
 </div>

--- a/www/tpl/TargetUnit.html
+++ b/www/tpl/TargetUnit.html
@@ -17,7 +17,7 @@
         <div class="topcoat-list__header" id="lblCurrentTrans">{{t 'view.lblCurrentTranslation'}}</div>
         <div class="srcbox"><div class="emphasized-small" id="lblSourceLang"></div><div class="emphasized center"><span id="srcPhrase"></span></div></div>
         <div class="tgtbox"><div class="emphasized-small" id="lbltargetLang"></div><div class="emphasized center"><span id="tgtPhrase" contenteditable="true"></span></div></div>
-        <div class="control-row"><button class="topcoat-button" id="btnNewRS"><span class="img-plus-small"></span> {{t 'view.lblNewRS'}}</button></div>
+        <ul class="topcoat-list__container chapter-list"><li class="topcoat-list__item li-tu"><div class="big-link" id="btnNewRS"><div class="chap-list__item emphasized refstring-list__item filter-burnt-orange"><span class="img-plus-small" style="padding-right: 16px;"></span>{{t 'view.lblNewRS'}}</div></div></li></ul>
         <div class="topcoat-list__header" id="lblAllTrans">{{t 'view.lblAllTranslations'}} <span class="right">{{t 'view.lblFrequency'}}</span></div>
         <ul class="topcoat-list__container chapter-list" id="RefStrings"></ul>
     </div>

--- a/www/tpl/TargetUnitList.html
+++ b/www/tpl/TargetUnitList.html
@@ -16,16 +16,18 @@
 <div id="kbSearch" class="scroller-notb">
     <div class="control-group">
         <div class="control-row"><span id="lblProjInfo"></span></div>
-        <!-- <div class="control-row"><button class="topcoat-button" id="btnNewTU"><span class="img-plus-small"></span> {{t 'view.lblNewTU'}}</button></div> -->
     </div>
     <div id="grpSearch">
         <div class="doc-search-bar"><input id="search" type="search" placeholder="{{ t 'view.dscSearch'}}" autocapitalize="off" class="topcoat-search-input doc-search-key"></div>
-        <div class="topcoat-list hide" style="overflow:hidden" id="lstSearch">
-            <h3 class="topcoat-list__header" id="lblSearchResults" style="display:none">{{t 'view.lblSearchResults'}}</h3>
-            <ul class="topcoat-list__container chapter-list" id="lstSearchResults"></ul>
+        <ul class="topcoat-list__container chapter-list" id="lstNewTU"><li class="topcoat-list__item li-tu"><div class="big-link" id="btnNewTU"><div class="chap-list__item emphasized refstring-list__item filter-burnt-orange"><span class="img-plus-small" style="padding-right: 16px;"></span>{{ t 'view.lblNewTU' }} </div></div></li></ul>
+        <div class="relative-search-bar" id="SearchBar">
+            <span class="search-label" id="SearchRS"></span>
+            <span class="search-label" id="lblTotals"></span>
+            <button class="search light-grey" id="SearchPrev"><span class="img-left-small"></span></button>
+            <button class="search light-grey" id="SearchNext"><span class="img-right-small"></span></button>
         </div>
-        </div>
-        <ul class="chapter-list topcoat-list__container" id="lstTU"></ul>
+                <!-- <div class="topcoat-list__header" id="lblResults"><span class="right">1-100 of 2000 <button class="search light-grey" id="SearchPrev"><span class="img-left-small"></span></button><button class="search light-grey" id="SearchNext"><span class="img-right-small"></span></button></span></div> -->
+        <ul class="topcoat-list__container chapter-list" id="lstTU"></ul>
     </div>
 </div>
 <div class="bottom-tb hide" id="tbBottom">

--- a/www/tpl/TargetUnitList.html
+++ b/www/tpl/TargetUnitList.html
@@ -16,7 +16,7 @@
 <div id="kbSearch" class="scroller-notb">
     <div class="control-group">
         <div class="control-row"><span id="lblProjInfo"></span></div>
-        <div class="control-row"><button class="topcoat-button" id="btnNewTU"><span class="img-plus-small"></span> {{t 'view.lblNewTU'}}</button></div>
+        <!-- <div class="control-row"><button class="topcoat-button" id="btnNewTU"><span class="img-plus-small"></span> {{t 'view.lblNewTU'}}</button></div> -->
     </div>
     <div id="grpSearch">
         <div class="doc-search-bar"><input id="search" type="search" placeholder="{{ t 'view.dscSearch'}}" class="topcoat-search-input doc-search-key"></div>
@@ -25,7 +25,6 @@
             <ul class="topcoat-list__container chapter-list" id="lstSearchResults"></ul>
         </div>
         </div>
-        <div class="control-row"></div>
         <ul class="chapter-list topcoat-list__container" id="lstTU"></ul>
     </div>
 </div>

--- a/www/tpl/TargetUnitList.html
+++ b/www/tpl/TargetUnitList.html
@@ -14,8 +14,11 @@
     </div>
 </div>
 <div id="kbSearch" class="scroller-notb">
+    <div class="control-group">
+        <div class="control-row"><span id="lblProjInfo"></span></div>
+        <div class="control-row"><button class="topcoat-button" id="btnNewTU"><span class="img-plus-small"></span> {{t 'view.lblNewTU'}}</button></div>
+    </div>
     <div id="grpSearch">
-        <div class="topcoat-list__header" id="lblAllTrans"><span id="lblProjInfo"></span></div>
         <div class="doc-search-bar"><input id="search" type="search" placeholder="{{ t 'view.dscSearch'}}" class="topcoat-search-input doc-search-key"></div>
         <div class="topcoat-list hide" style="overflow:hidden" id="lstSearch">
             <h3 class="topcoat-list__header" id="lblSearchResults" style="display:none">{{t 'view.lblSearchResults'}}</h3>

--- a/www/tpl/TargetUnitList.html
+++ b/www/tpl/TargetUnitList.html
@@ -22,9 +22,9 @@
         <ul class="topcoat-list__container chapter-list" id="lstNewTU"><li class="topcoat-list__item li-tu"><div class="big-link" id="btnNewTU"><div class="chap-list__item emphasized refstring-list__item filter-burnt-orange"><span class="img-plus-small" style="padding-right: 16px;"></span>{{ t 'view.lblNewTU' }} </div></div></li></ul>
         <div class="relative-search-bar" id="SearchBar">
             <span class="search-label" id="SearchRS"></span>
-            <span class="search-label" id="lblTotals"></span>
-            <button class="search light-grey" id="SearchPrev"><span class="img-left-small"></span></button>
-            <button class="search light-grey" id="SearchNext"><span class="img-right-small"></span></button>
+            <span class="search-label" id="lblTotals">{{ t 'view.lblNoEntries'}}</span>
+            <button class="search light-grey" id="SearchPrev" disabled><span class="img-left-small"></span></button>
+            <button class="search light-grey" id="SearchNext" disabled><span class="img-right-small"></span></button>
         </div>
                 <!-- <div class="topcoat-list__header" id="lblResults"><span class="right">1-100 of 2000 <button class="search light-grey" id="SearchPrev"><span class="img-left-small"></span></button><button class="search light-grey" id="SearchNext"><span class="img-right-small"></span></button></span></div> -->
         <ul class="topcoat-list__container chapter-list" id="lstTU"></ul>

--- a/www/tpl/TargetUnitList.html
+++ b/www/tpl/TargetUnitList.html
@@ -19,7 +19,7 @@
         <!-- <div class="control-row"><button class="topcoat-button" id="btnNewTU"><span class="img-plus-small"></span> {{t 'view.lblNewTU'}}</button></div> -->
     </div>
     <div id="grpSearch">
-        <div class="doc-search-bar"><input id="search" type="search" placeholder="{{ t 'view.dscSearch'}}" class="topcoat-search-input doc-search-key"></div>
+        <div class="doc-search-bar"><input id="search" type="search" placeholder="{{ t 'view.dscSearch'}}" autocapitalize="off" class="topcoat-search-input doc-search-key"></div>
         <div class="topcoat-list hide" style="overflow:hidden" id="lstSearch">
             <h3 class="topcoat-list__header" id="lblSearchResults" style="display:none">{{t 'view.lblSearchResults'}}</h3>
             <ul class="topcoat-list__container chapter-list" id="lstSearchResults"></ul>

--- a/www/tpl/TargetUnitList.html
+++ b/www/tpl/TargetUnitList.html
@@ -5,11 +5,17 @@
     <div class="topcoat-navigation-bar__item">
         <a class="topcoat-icon-button--quiet back-button" href="index.html"><span class="topcoat-icon topcoat-icon--back"></span></a>
     </div>
-    <div class="topcoat-navigation-bar__item half"><h2>{{t 'view.ttlTranslations'}}</h2></div>
+    <div class="topcoat-navigation-bar__item half"><h2>{{t 'view.lblKB'}}</h2></div>
+    <div class="topcoat-navigation-bar__item right">
+        <button id="More-menu" title="{{ t 'view.dscMoreActions'}}" class="topcoat-icon-button--quiet toolbar-button"><span class="topcoat-icon topcoat-icon--more-menu"></span></button>
+        <div id="MoreActionsMenu" aria-haspopup="true" class="dropdown-vertical">
+            <div id="mnuSelect"><span class="label" id="lblSelect">{{ t 'view.lblSelectDoc'}}</span></div>
+        </div>
+    </div>
 </div>
 <div id="kbSearch" class="scroller-notb">
     <div id="grpSearch">
-        <div class="topcoat-list__header" id="lblAllTrans"><span id="lblTotalTranslations" class="right"></span></div>
+        <div class="topcoat-list__header" id="lblAllTrans"><span id="lblProjInfo"></span></div>
         <div class="doc-search-bar"><input id="search" type="search" placeholder="{{ t 'view.dscSearch'}}" class="topcoat-search-input doc-search-key"></div>
         <div class="topcoat-list hide" style="overflow:hidden" id="lstSearch">
             <h3 class="topcoat-list__header" id="lblSearchResults" style="display:none">{{t 'view.lblSearchResults'}}</h3>
@@ -17,7 +23,12 @@
         </div>
         </div>
         <div class="control-row"></div>
-        <ul class="chapter-list topcoat-list__container" id="lstBooks"></ul>
-        <div class="chapter-list topcoat-list__container" id="Container" style="width:100%">
+        <ul class="chapter-list topcoat-list__container" id="lstTU"></ul>
     </div>
-</div>    
+</div>
+<div class="bottom-tb hide" id="tbBottom">
+    <div id="OKCancelButtons">
+        <button id="btnDelete" title="{{ t 'view.ttlDelete' }}" class="topcoat-button danger" disabled><span class="btn-delete" role="img"></span> {{ t 'view.ttlDelete'}}</button>
+        <button class="topcoat-button" id="btnDone"><span id="lblDone">{{t 'view.lblDone'}}</span></button>
+    </div>
+</div>


### PR DESCRIPTION
Fixes #507 .

Changes proposed in this request:

- KB editor available from Settings screen, shows paged target unit list (100 items per page), with an optional search filter to find individual items.
- New TU functionality available from KB editor (New Entry button) -- user must enter one source and at least one target (can add more via an "Add Translation" button).
- Edit TU functionality available from KB editor (clicking on an item in the list). User can edit the RefString or create a new one (via an "Add Translation" button).

@adapt-it/developers
