### PR TITLE
Fix #552

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -19,6 +19,7 @@
     <preference name="SplashShowOnlyFirstTime" value="false" />
     <preference name="AutoHideSplashScreen" value="true" />
     <platform name="android">
+        <hook type="before_build" src="scripts/before-build.js" />
         <plugin name="cordova-sqlite-evcore-extbuild-free" spec="^0.15.1" />
         <plugin name="cordova-plugin-statusbar" spec="^2.4.3" />
         <!-- SDK 26/Android 8.x: lowest SDK that supports adaptive icons (for splash / app icon) -->

--- a/scripts/before-build.js
+++ b/scripts/before-build.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+
+module.exports = function(ctx) {
+    // Android -- copy the build-extras.gradle file into the app directory so it gets run
+    if (ctx.opts.platforms.includes('android'))  {
+        fs.copyFile(path.join(ctx.opts.projectRoot, 'scripts/build-extras.gradle'), path.join(ctx.opts.projectRoot, 'platforms/android/app/build-extras.gradle'), (err) => {
+            if (err) throw err;
+            console.log('build-extras.gradle copied to android/app directory');
+        });
+    }
+};

--- a/scripts/build-extras.gradle
+++ b/scripts/build-extras.gradle
@@ -1,0 +1,13 @@
+// This file is included at the beginning of `build.gradle`
+
+// Here we'll only add one item to the build.gradle file -- whether or not to add the dependencies blob to the app
+android {
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        // This is for the signed .apk that we post to GitHub, so the dependency metadata isn't relevant.
+        includeInApk = false
+        // Enable dependency metadata when building Android App Bundles.
+        // This is for the Google Play Store, so we'll want the metadata.
+        includeInBundle = true
+    }
+}


### PR DESCRIPTION
Adding pre-build script to copy over build-extras.gradle file for Android builds. This file has a dependenciesInfo configuration that tells Android Studio to NOT include the dependencies blob when creating signed APKs.
