### PR TITLE
Bug fixes

### DIFF
--- a/www/js/views/DocumentViews.js
+++ b/www/js/views/DocumentViews.js
@@ -6294,6 +6294,11 @@ define(function (require) {
                             chap.save({name: newChapterName});
                             if (firstChapWithVerses === null && chap.get('versecount') !== 0) {
                                 firstChapWithVerses = chap;
+                                // it's possible we also need to change the lastAdaptedName for this chapter book
+                                if (this.model.get("lastAdaptedName").indexOf(bookName) > -1) {
+                                    // we have chapters -- use the first one that has some verses
+                                    this.model.set('lastAdaptedName', chap.get('name'));
+                                }
                             }
                         }
                         // last document and chapter (if the first import)
@@ -6301,8 +6306,10 @@ define(function (require) {
                         if (this.model.get('lastDocument') === bookName) {
                             this.model.set('lastDocument', newName);
                         }
-                        if (this.model.get('lastAdaptedName') === "" && firstChapWithVerses !== null) {
-                            this.model.set('lastAdaptedName', firstChapWithVerses.get('name'));
+                        // test for lastAdaptedName === bookName (first import for a plain text file)  
+                        if (this.model.get("lastAdaptedName") === bookName) {
+                            // no chapter -- set to newName
+                            this.model.set('lastAdaptedName', newName);
                         }
                         if (this.model.get('lastAdaptedBookID') === 0) {
                             this.model.set('lastAdaptedBookID', book.get("bookid"));

--- a/www/js/views/DocumentViews.js
+++ b/www/js/views/DocumentViews.js
@@ -287,6 +287,9 @@ define(function (require) {
                     $("#verifyNameControls").show();
                     $("#lblDirections").html(i18n.t("view.dscStatusImportSuccess", {document: fileName}));
                     $("#BookName").val(bookName);
+                    // select the book name text
+                    $("#BookName").trigger("focus");
+                    $("#BookName").trigger("select");
                 }
                 // display the OK button
                 $("#OK").removeClass("hide");

--- a/www/js/views/SearchViews.js
+++ b/www/js/views/SearchViews.js
@@ -167,12 +167,20 @@ define(function (require) {
                 window.Application.currentProject.set('lastDocument', "");
                 window.Application.currentProject.set('lastAdaptedBookID', 0);
                 window.Application.currentProject.set('lastAdaptedChapterID', 0);
+                window.Application.currentProject.set('lastAdaptedName', "");
                 window.Application.currentProject.save();
             } else if (deletedCurrentDoc === true) {
                 // We just deleted the current Document/book;
-                // reset the current chapter and book to the first book in our collection                
+                // reset the current chapter and book to the first book in our collection
+                // fall back on clearing out the lastAdapted stuff
+                window.Application.currentProject.set('lastDocument', "");
+                window.Application.currentProject.set('lastAdaptedBookID', 0);
+                window.Application.currentProject.set('lastAdaptedChapterID', 0);
+                window.Application.currentProject.set('lastAdaptedName', "");
+                // now try to get the first book in the book list              
                 var bk = window.Application.BookList.at(0);
                 if (bk) {
+                    // got it -- set the lastAdapted stuff to the first chapter
                     var cid = bk.get("chapters")[0];
                     window.Application.currentProject.set('lastDocument', bk.get("name"));
                     window.Application.currentProject.set('lastAdaptedBookID', bk.get("bookid"));
@@ -184,8 +192,8 @@ define(function (require) {
                         // can't get the chapter -- just clear out the lastAdaptedName value
                         window.Application.currentProject.set('lastAdaptedName', "");
                     }
-                    window.Application.currentProject.save();
                 }
+                window.Application.currentProject.save();
             }
         },
         ////////


### PR DESCRIPTION
Fixes #559, #560, #561 .

Changes proposed in this request:

- Automatically select the text in the book name edit field after import, so users don't have to hit backspace forever if they want to change the book name.
- Clear out the old cruft when the user deletes documents in the Browse/Search view.
- Fix the logic to update names with/without chapters at the end of the import, if the lastAdaptedName was set during import (i.e., if this is the first document being imported).

