### PR TITLE
Patch fixes

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -99,6 +99,42 @@
         <resource-file src="www/res/icon/ios/usx_44.png" />
         <resource-file src="www/res/icon/ios/usx_64.png" />
         <resource-file src="www/res/icon/ios/usx_320.png" />
+        <!-- EDB 5 Apr 2024: new privacy API requirement for iOS / this fills in PrivacyInfo.xcprivacy template -->
+        <privacy-manifest>
+          <key>NSPrivacyTracking</key>
+          <false />
+          <key>NSPrivacyTrackingDomains</key>
+          <array />
+          <key>NSPrivacyCollectedDataTypes</key>
+          <array/>
+          <key>NSPrivacyAccessedAPITypes</key>
+          <array>
+          <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>0A2A.1</string>
+            </array>
+          </dict>
+          <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>E174.1</string>
+            </array>
+          </dict>
+          <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+          </dict>
+          </array>
+        </privacy-manifest>
         <!-- EDB 8/16/21 TODO: config-file items are up to date, but some icon files do need to be
         manually copied over into the XCode project before releasing. -->
         <config-file mode="replace" parent="UISupportedInterfaceOrientations" target="*-Info.plist">

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "cordova-android": "^12.0.1",
     "cordova-clipboard": "github:ihadeed/cordova-clipboard",
-    "cordova-ios": "^7.0.1",
+    "cordova-ios": "^7.1.0",
     "cordova-plugin-add-swift-support": "^2.0.2",
     "cordova-plugin-chooser": "^1.3.2",
     "cordova-plugin-customurlscheme": "^5.0.2",

--- a/www/js/views/ProjectViews.js
+++ b/www/js/views/ProjectViews.js
@@ -705,7 +705,7 @@ define(function (require) {
                     {
                         hint: true,
                         highlight: true,
-                        minLength: 1
+                        minLength: 2
                     },
                     {
                         name: 'languages',
@@ -723,7 +723,7 @@ define(function (require) {
                             return data.attributes.name;
                         },
                         source: this.languageMatches(this.theLangs),
-                        limit: 25,
+                        limit: 200,
                         templates: {
                             empty: ['<div>No languages found</div>'].join('\n'),
                             pending: ['<div>Searching...</div>'].join('\n'),
@@ -734,16 +734,22 @@ define(function (require) {
                                     strSuggestion += data.attributes.localname
                                     strSuggestion += '&nbsp;(' + data.attributes.tag + ')<span class=\"subtext\">';
                                     strSuggestion += (data.attributes.name != null) ? data.attributes.name : data.attributes.names[0];
+                                    strSuggestion += (data.attributes.regionname != null) ? (" / " + data.attributes.regionname) : "";
                                     strSuggestion += '</span>';
                                 } else if (data.attributes.localnames != null && data.attributes.localnames.length > 0) {
                                     strSuggestion += data.attributes.localnames[0];
                                     strSuggestion += '&nbsp;(' + data.attributes.tag + ')<span class=\"subtext\">';
                                     strSuggestion += (data.attributes.name != null) ? data.attributes.name : data.attributes.names[0];
+                                    strSuggestion += (data.attributes.regionname != null) ? (" / " + data.attributes.regionname) : "";
                                     strSuggestion += '</span>';
                                 } else if (data.attributes.name != null && data.attributes.name.length > 0) {
-                                    strSuggestion += data.attributes.name + '&nbsp;(' + data.attributes.tag + ')';
+                                    strSuggestion += data.attributes.name + '&nbsp;(' + data.attributes.tag + ')<span class=\"subtext\">';
+                                    strSuggestion += (data.attributes.regionname != null) ? data.attributes.regionname : "";
+                                    strSuggestion += '</span>';
                                 } else {
-                                    strSuggestion += data.attributes.names[0] + '&nbsp;(' + data.attributes.tag + ')';
+                                    strSuggestion += data.attributes.names[0] + '&nbsp;(' + data.attributes.tag + ')<span class=\"subtext\">';
+                                    strSuggestion += (data.attributes.regionname != null) ? data.attributes.regionname : "";
+                                    strSuggestion += '</span>';
                                 }
                                 // close out and return the suggestion
                                 strSuggestion += '</div>';;
@@ -778,7 +784,7 @@ define(function (require) {
                     {
                         hint: true,
                         highlight: true,
-                        minLength: 1
+                        minLength: 2
                     },
                     {
                         name: 'languages',
@@ -796,7 +802,7 @@ define(function (require) {
                             return data.attributes.name;
                         },
                         source: this.languageMatches(this.theLangs),
-                        limit: 25,
+                        limit: 200,
                         templates: {
                             empty: ['<div>No languages found</div>'].join('\n'),
                             pending: ['<div>Searching...</div>'].join('\n'),
@@ -807,16 +813,22 @@ define(function (require) {
                                     strSuggestion += data.attributes.localname
                                     strSuggestion += '&nbsp;(' + data.attributes.tag + ')<span class=\"subtext\">';
                                     strSuggestion += (data.attributes.name != null) ? data.attributes.name : data.attributes.names[0];
+                                    strSuggestion += (data.attributes.regionname != null) ? (" / " + data.attributes.regionname) : "";
                                     strSuggestion += '</span>';
                                 } else if (data.attributes.localnames != null && data.attributes.localnames.length > 0) {
                                     strSuggestion += data.attributes.localnames[0];
                                     strSuggestion += '&nbsp;(' + data.attributes.tag + ')<span class=\"subtext\">';
                                     strSuggestion += (data.attributes.name != null) ? data.attributes.name : data.attributes.names[0];
+                                    strSuggestion += (data.attributes.regionname != null) ? (" / " + data.attributes.regionname) : "";
                                     strSuggestion += '</span>';
                                 } else if (data.attributes.name != null && data.attributes.name.length > 0) {
-                                    strSuggestion += data.attributes.name + '&nbsp;(' + data.attributes.tag + ')';
+                                    strSuggestion += data.attributes.name + '&nbsp;(' + data.attributes.tag + ')<span class=\"subtext\">';
+                                    strSuggestion += (data.attributes.regionname != null) ? data.attributes.regionname : "";
+                                    strSuggestion += '</span>';
                                 } else {
-                                    strSuggestion += data.attributes.names[0] + '&nbsp;(' + data.attributes.tag + ')';
+                                    strSuggestion += data.attributes.names[0] + '&nbsp;(' + data.attributes.tag + ')<span class=\"subtext\">';
+                                    strSuggestion += (data.attributes.regionname != null) ? data.attributes.regionname : "";
+                                    strSuggestion += '</span>';
                                 }
                                 // close out and return the suggestion
                                 strSuggestion += '</div>';;

--- a/www/res/css/styles.css
+++ b/www/res/css/styles.css
@@ -1370,7 +1370,7 @@ div.preview div.pile {
 .subtext {
     display: block;
     font-size: 0.6rem;
-    color: #999;
+    color: #555;
 }
 .topcoat-checkbox__checkmark {
     margin-right: 6px;
@@ -1905,26 +1905,8 @@ typeahead styles
 }
 
 #scrollable-dropdown-menu .tt-menu {
-  max-height: 175px;
+    max-height: max(175px, calc(100vh - 300px)); /* available space - keyboard (vertical), or 175px if that's too small */
     overflow-y: auto;
-}
-.tt-menu::-webkit-scrollbar {
-    background-color: rgb(221, 225, 225);
-    width: 12px;
-}
-.tt-menu::-webkit-scrollbar-thumb {
-    background-color: #ccc;
-    border-radius: 10px;
-    -moz-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
-    -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
-    box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
-}
-.tt-menu::-webkit-scrollbar-track {
-    background-color: rgb(221, 225, 225);
-    border-radius: 10px;
-    -moz-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
-    -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
-    box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
 }
 
 .tt-menu {

--- a/www/tpl/ProjectSourceLanguage.html
+++ b/www/tpl/ProjectSourceLanguage.html
@@ -1,4 +1,4 @@
-<div id="source" class="control-group" style="height:100%;">
+<div id="source" class="control-group" style="height:100%; overflow: visible;">
     <div class="control-row" style="padding-bottom: 0"><label for="LanguageName">* {{ t 'view.lblSourceLanguageName'}}</label></div>
     <div class="control-row full" id="scrollable-dropdown-menu"><input type="text" id="LanguageName" class="topcoat-text-input full typeahead" value="{{SourceLanguageName}}" placeholder={{ t 'view.lblStartTyping'}} required></div>
     <div class="control-row"><label for="LanguageVariant">{{ t 'view.lblLanguageVariant'}}</label><input type="text" id="LanguageVariant" class="topcoat-text-input full" value="{{SourceVariant}}"></div>

--- a/www/tpl/ProjectTargetLanguage.html
+++ b/www/tpl/ProjectTargetLanguage.html
@@ -1,4 +1,4 @@
-<div id="source" class="control-group" style="height:100%;">
+<div id="source" class="control-group" style="height:100%; overflow: visible;">
     <div class="control-row" style="padding-bottom: 0"><label for="LanguageName">* {{ t 'view.lblTargetLanguageName'}}</label></div>
     <div class="control-row full"><input type="text" id="LanguageName" class="topcoat-text-input full typeahead" value="{{TargetLanguageName}}" placeholder={{ t 'view.lblStartTyping'}} required></div>
     <div class="control-row"><label for="LanguageVariant">{{ t 'view.lblLanguageVariant'}}</label><input type="text" id="LanguageVariant" class="topcoat-text-input full" value="{{TargetVariant}}"></div>


### PR DESCRIPTION
Fixes #573, #574.

Changes proposed in this request:

- Add info for iOS privacy manifest file
- Rework languages dropdown in New Project wizard:
  - Increase size of dropdown when possible
  - Increase max number of results returned to 200 (was 25)

Each search result is now a 2-line listing:

- If there is an autonym:
  - First line contains the autonym followed by the code in parenthesis - e.g. "Español (es-AR)"
  - Second line contains the English name of the language followed by a slash and the region - e.g. "Spanish / Argentina"
- If there is no autonym:
  - First line contains the English name of the language followed by the code in parenthesis - e.g. "Spanish (es-BRAI)"
  - Second line contains the region (no leading slash) - e.g. "Spain"

@adapt-it/developers
