### PR TITLE
Oops / Android bump needed

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="55" defaultlocale="en" id="org.adaptit.adaptitmobile" ios-CFBundleVersion="1" version="1.16.3" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:gap="http://phonegap.com/ns/1.0">
+<widget android-versionCode="56" defaultlocale="en" id="org.adaptit.adaptitmobile" ios-CFBundleVersion="1" version="1.16.3" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:gap="http://phonegap.com/ns/1.0">
     <name short="Adapt It Mobile" xml:lang="en">Adapt It Mobile</name>
     <description xml:lang="en">
         An open source application for translating between related languages.

--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -80,7 +80,7 @@ define(function (require) {
             currentProject: null,
             localURLs: [],
             version: "1.16.3", // appended with Android / iOS build info
-            AndroidBuild: "55", // (was milestone release #)
+            AndroidBuild: "56", // (was milestone release #)
             iOSBuild: "1", // iOS uploaded build number for this release (increments from 1 for each release) 
             importingURL: "", // for other apps in Android-land sending us files to import
 


### PR DESCRIPTION
Accidentally added the .APK instead of the .AAB to the Google Play store. Needed to bump the Android build to 56 for 1.16.3 in order to release the .AAB instead. :/
