### PR TITLE
Fix #587

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="58" defaultlocale="en" id="org.adaptit.adaptitmobile" ios-CFBundleVersion="1" version="1.16.5" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:gap="http://phonegap.com/ns/1.0">
+<widget android-versionCode="59" defaultlocale="en" id="org.adaptit.adaptitmobile" ios-CFBundleVersion="1" version="1.16.6" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:gap="http://phonegap.com/ns/1.0">
     <name short="Adapt It Mobile" xml:lang="en">Adapt It Mobile</name>
     <description xml:lang="en">
         An open source application for translating between related languages.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-it-mobile",
-  "version": "1.16.5",
+  "version": "1.16.6",
   "description": "Adapt It Mobile",
   "repository": {
     "type": "git",

--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -79,8 +79,8 @@ define(function (require) {
             searchIndex: 0,
             currentProject: null,
             localURLs: [],
-            version: "1.16.5", // appended with Android / iOS build info
-            AndroidBuild: "58", // (was milestone release #)
+            version: "1.16.6", // appended with Android / iOS build info
+            AndroidBuild: "59", // (was milestone release #)
             iOSBuild: "1", // iOS uploaded build number for this release (increments from 1 for each release) 
             importingURL: "", // for other apps in Android-land sending us files to import
 


### PR DESCRIPTION
Fixes #587 .

Changes proposed in this request:

- Do _not_ add phrase to KB when merging -- this is handled later when the user moves out of the edit field (unfocus event).
- Fix KB removal call when user removes the phrase (code needed to strip out punctuation, so it wasn't matching anything in the KB).
- Remove some half-implemented "auto-phrase" code (see #109) that was causing erratic behavior.
- bump version to patch release 1.16.6 (59)

@adapt-it/developers
