### PR TITLE
A couple more fixes for #604

### DIFF
--- a/www/js/Application.js
+++ b/www/js/Application.js
@@ -664,8 +664,8 @@ define(function (require) {
             importBooks: function (id) {
                 console.log("importBooks");
                 // update the book and chapter lists, then show the import docs view
-                $.when(window.Application.BookList.fetch({reset: true, data: {name: ""}})).done(function () {
-                    $.when(window.Application.ChapterList.fetch({reset: true, data: {name: ""}})).done(function () {
+                $.when(window.Application.BookList.fetch({reset: true, data: {projectid: window.Application.currentProject.get("projectid")}})).done(function () {
+                    $.when(window.Application.ChapterList.fetch({reset: true, data: {projectid: window.Application.currentProject.get("projectid")}})).done(function () {
                         var proj = window.Application.currentProject;
                         if (proj !== null) {
                             importDocView = new DocumentViews.ImportDocumentView({model: proj});
@@ -693,13 +693,17 @@ define(function (require) {
             // Search / browse chapter view -- all books/chapters in current project
             lookupChapter: function (id) {
                 console.log("lookupChapter");
-                var proj = window.Application.ProjectList.where({projectid: id});
-                if (proj !== null) {
-                    lookupView = new SearchViews.LookupView({model: proj[0]});
-                    window.Application.main.show(lookupView);
-                } else {
-                    console.log("no project defined");
-                }
+                $.when(window.Application.BookList.fetch({reset: true, data: {projectid: window.Application.currentProject.get("projectid")}})).done(function () {
+                    $.when(window.Application.ChapterList.fetch({reset: true, data: {projectid: window.Application.currentProject.get("projectid")}})).done(function () {
+                        var proj = window.Application.currentProject;
+                        if (proj !== null) {
+                            lookupView = new SearchViews.LookupView({model: proj});
+                            window.Application.main.show(lookupView);
+                        } else {
+                            alert("No current project defined -- ignoring open() call");
+                        }
+                    });
+                });
             },
             // Adapt View (the reason we're here)
             adaptChapter: function (id) {

--- a/www/js/views/ProjectViews.js
+++ b/www/js/views/ProjectViews.js
@@ -1914,11 +1914,14 @@ define(function (require) {
                         step++;
                         this.ShowStep(step);
                     } else {
+                        var bMultipleProject = false;
                         // last step -- finish up
                         // save the model
                         this.model.save();
                         if (window.Application.currentProject) {
-                            // There's already a project defined. Clear out any local 
+                            // There's already a project defined.
+                            bMultipleProject = true;
+                            // Clear out any local 
                             // chapter/book/sourcephrase/KB stuff so it loads from our new project instead
                             window.Application.BookList.length = 0;
                             window.Application.ChapterList.length = 0;
@@ -1931,7 +1934,11 @@ define(function (require) {
                         window.Application.currentBookmark = this.bookmark;
                         localStorage.setItem("CurrentProjectID", window.Application.currentProject.get("projectid"));
                         // head back to the home page
-                        window.history.back(); // return to the home page
+                        if (bMultipleProject === true) {
+                            window.history.go(-3); // back 3 jumps to the home page 
+                        } else {
+                            window.history.back(); // back 1 jump to the home page
+                        }
                     }
                 }
             },

--- a/www/js/views/ProjectViews.js
+++ b/www/js/views/ProjectViews.js
@@ -985,8 +985,8 @@ define(function (require) {
 
                     // done setting the project and bookmark list -- head back to the home page
                     if (window.history.length > 1) {
-                        // there actually is a history -- go back
-                        window.history.back();
+                        // jump back 2 to the home page
+                        window.history.go(-2);
                     } else {
                         // no history (import link from outside app) -- just go home
                         window.location.replace("");


### PR DESCRIPTION
Changes proposed in this request:

- For import and search pages, fetch only the books/chapters for the current project 
- For new projects created from the Manage Projects settings page, return to the home page when finished
- For switching between projects, return to the home page
