### PR TITLE
Fix #617

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "adaptation"
   ],
   "devDependencies": {
-    "cordova-android": "^14.0.0",
+    "cordova-android": "^14.0.1",
     "cordova-clipboard": "github:ihadeed/cordova-clipboard",
     "cordova-ios": "^7.1.1",
     "cordova-plugin-add-swift-support": "^2.0.2",

--- a/www/js/views/AdaptViews.js
+++ b/www/js/views/AdaptViews.js
@@ -96,7 +96,7 @@ define(function (require) {
         // This method also takes into account the software / on-screen keyboard
         scrollToView = function (element) {
             // viewport dimensions
-            var docViewTop = $("#content").scrollTop();
+            var docViewTop = $("#content").scrollTop(); //px
             var docViewHeight = document.documentElement.clientHeight - $("#title").outerHeight(); // height of #content element
             var docViewBottom = 0; // viewport area to work with -- calculated below
             // element dimensions
@@ -134,7 +134,8 @@ define(function (require) {
             console.log("- eltBottom: " + eltBottom + ", docViewHeight: " + docViewHeight + ", docViewBottom: " + docViewBottom);
             console.log("- eltTop: " + eltTop + ", docViewTop: " + docViewTop);
             // now check to see if the content needs scrolling
-            if ((eltBottom > docViewBottom) || (eltTop < docViewTop)) {
+            if ((eltBottom > docViewBottom) || (eltTop < docViewTop) ||
+                (device.platform === "Android")) {
                  // Not in view -- scroll to the element
                 if (($(element).height() * 2) < docViewHeight) {
                     // more than 2 rows available in viewport -- center it

--- a/www/js/views/SearchViews.js
+++ b/www/js/views/SearchViews.js
@@ -1244,18 +1244,39 @@ define(function (require) {
                     console.log("SearchViews:onShow() - need to refresh the chapter list");
                     window.Application.ChapterList.fetch({reset: true, data: {projectid: window.Application.currentProject.get("projectid")}});
                 }
-                this.bookList = window.Application.BookList;
-                this.chapterList = window.Application.ChapterList;
-                // initial sort - name
-                this.bookList.comparator = 'name';
-                this.bookList.sort();
-                this.bookList.each(function (model, index) {
-                    lstBooks += "<li class=\"topcoat-list__item ttlbook\" id=\"ttl-" + model.get("bookid")  + "\"><div class=\"big-link\" id=\"bk-" + model.get("bookid") + "\"><span class=\"li-chk\"></span><span class=\"btn-book\"></span>" + model.get("name") + "</div></li><ul class=\"topcoat-list__container chapter-list cl-indent\" id=\"lst-" + model.get("bookid") + "\" style=\"display:none\"></ul>";
-                });
-                $("#lstBooks").html(lstBooks);
-                // if there's only one book, "open" it and show the chapters
-                if (this.bookList.length === 1) {
-                    $("#lstBooks > h3").first().mouseup();
+                if (window.Application.BookList.length === 0) {
+                    // booklist is empty; this shouldn't be the case, but can happen if the local copy is out of sync
+                    // we need to call fetch() to pull the latest data, and then update the UI when the fetch call completes
+                    console.log("SearchViews:onShow() - need to refresh book list");
+                    $.when(window.Application.BookList.fetch({reset: true, data: {projectid: window.Application.currentProject.get("projectid")}})).done(function () {
+                        var bookList = window.Application.BookList;
+                        bookList.comparator = 'name';
+                        bookList.sort();
+                        bookList.each(function (model, index) {
+                            lstBooks += "<li class=\"topcoat-list__item ttlbook\" id=\"ttl-" + model.get("bookid")  + "\"><div class=\"big-link\" id=\"bk-" + model.get("bookid") + "\"><span class=\"li-chk\"></span><span class=\"btn-book\"></span>" + model.get("name") + "</div></li><ul class=\"topcoat-list__container chapter-list cl-indent\" id=\"lst-" + model.get("bookid") + "\" style=\"display:none\"></ul>";
+                        });
+                        $("#lstBooks").html(lstBooks);
+                        // if there's only one book, "open" it and show the chapters
+                        if (bookList.length === 1) {
+                            $("#lstBooks > h3").first().mouseup();
+                        }    
+    
+                    });
+                } else {
+                    // book list is populated - update the UI
+                    this.bookList = window.Application.BookList;
+                    this.chapterList = window.Application.ChapterList;
+                    // initial sort - name
+                    this.bookList.comparator = 'name';
+                    this.bookList.sort();
+                    this.bookList.each(function (model, index) {
+                        lstBooks += "<li class=\"topcoat-list__item ttlbook\" id=\"ttl-" + model.get("bookid")  + "\"><div class=\"big-link\" id=\"bk-" + model.get("bookid") + "\"><span class=\"li-chk\"></span><span class=\"btn-book\"></span>" + model.get("name") + "</div></li><ul class=\"topcoat-list__container chapter-list cl-indent\" id=\"lst-" + model.get("bookid") + "\" style=\"display:none\"></ul>";
+                    });
+                    $("#lstBooks").html(lstBooks);
+                    // if there's only one book, "open" it and show the chapters
+                    if (this.bookList.length === 1) {
+                        $("#lstBooks > h3").first().mouseup();
+                    }    
                 }
             },
             

--- a/www/res/css/styles.css
+++ b/www/res/css/styles.css
@@ -495,7 +495,6 @@ button.light-grey {
 .scroller {
     border-top: 1px solid #aaa;
     bottom: 0;
-    bottom: max(calc(env(safe-area-inset-bottom)), 0);
     left: 0;
     overflow: auto;
     position: fixed;


### PR DESCRIPTION
Fixes #617  .

Changes proposed in this request:

- Set bottom of scroller to 0 (the safe-area-inset-bottom values are bad on Android), so manual scrolling works properly. This bug was introduced in AIM 1.18.0, so it should be transparent to users upgrading from previous releases
- Always auto- recenter the focused source phrase in Android, as the view port wasn't returning proper values. This should also be an issue in older versions when adapting.
- updated Cordova-android to 14.0.1
- Add a tweak to fetch the book list in the search page if the collection is empty

@adapt-it/developers
